### PR TITLE
circleci, gitrepo: add code skeleton

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@dev:go-test
+  architect: giantswarm/architect@0.4.3
 
 workflows:
   go-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,12 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@0.4.2
+  architect: giantswarm/architect@dev:go-test
 
 workflows:
   go-build:
     jobs:
-      - architect/go-build:
-          name: go-build-gitrepo
-          binary: gitrepo
+      - architect/go-test:
+          name: go-test-gitrepo
           # Needed to trigger job also on git tag.
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,14 @@
-version: 2
-jobs:
-  build:
-    machine: true
-    steps:
-    - checkout
+version: 2.1
+orbs:
+  architect: giantswarm/architect@0.4.2
 
-    - run: |
-        wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
-        chmod +x ./architect
-        ./architect version
-    - run: ./architect build
-    - deploy:
-        command: |
-          if [ "${CIRCLE_BRANCH}" == "master" ]; then
-            ./architect deploy
-          fi
+workflows:
+  go-build:
+    jobs:
+      - architect/go-build:
+          name: go-build-gitrepo
+          binary: gitrepo
+          # Needed to trigger job also on git tag.
+          filters:
+            tags:
+              only: /^v.*/

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/giantswarm/gitrepo
+
+go 1.13
+
+require gopkg.in/src-d/go-billy.v4 v4.3.2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/src-d/go-billy.v4 v4.3.2 h1:0SQA1pRztfTFx2miS8sA97XvooFeNOmvUenF4o0EcVg=
+gopkg.in/src-d/go-billy.v4 v4.3.2/go.mod h1:nDjArDMp+XMs1aFAESLRjfGSgfvoYN0hDfzEk0GjC98=

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,12 @@
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/src-d/go-billy.v4 v4.3.2 h1:0SQA1pRztfTFx2miS8sA97XvooFeNOmvUenF4o0EcVg=
 gopkg.in/src-d/go-billy.v4 v4.3.2/go.mod h1:nDjArDMp+XMs1aFAESLRjfGSgfvoYN0hDfzEk0GjC98=

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -1,0 +1,32 @@
+package gitrepo
+
+import (
+	"context"
+
+	"gopkg.in/src-d/go-billy.v4"
+)
+
+type Config struct {
+	AuthBasicToken string
+	Dir            string
+	URL            string
+}
+
+type Repo struct {
+	authBasicToken string
+	url            string
+
+	fs billy.Filesystem
+}
+
+func New(cnfig Config) (*Repo, error) {
+	r := &Repo{}
+
+	return r, nil
+}
+
+func (r *Repo) EnsureUpToDate(ctx context.Context) error {
+}
+
+func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
+}

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -19,14 +19,16 @@ type Repo struct {
 	fs billy.Filesystem
 }
 
-func New(cnfig Config) (*Repo, error) {
+func New(config Config) (*Repo, error) {
 	r := &Repo{}
 
 	return r, nil
 }
 
 func (r *Repo) EnsureUpToDate(ctx context.Context) error {
+	return nil
 }
 
 func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
+	return "", nil
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6844.

We need to fetch git repositories to be able to recreate dev version for VOO. We want this code in one place so it can be used by both architect and opsctl. In the future this may also replace caching for installations repository in opsctl.