### PR TITLE
Filter semver tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ c := Config{
 }
 repo, err := New(c)
 version, err := repo.ResolveVersion(ctx, "master")
-// version is v0.0.0-2e7604b8b3806b20ff305eb4e1a852c784ba34ca
+// version is 0.0.0-2e7604b8b3806b20ff305eb4e1a852c784ba34ca
 ```
 

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -3,6 +3,7 @@ package gitrepo
 import (
 	"context"
 	"io"
+	"strings"
 
 	"github.com/giantswarm/microerror"
 	"github.com/go-errors/errors"
@@ -148,12 +149,12 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 		for {
 			tag, ok := tags[c.Hash.String()]
 			if ok {
-				lastTag = tag
+				lastTag = strings.TrimPrefix(strings.TrimSpace(tag), "v")
 				break
 			}
 			c, err = c.Parent(0)
 			if errors.Is(err, object.ErrParentNotFound) {
-				lastTag = "v0.0.0"
+				lastTag = "0.0.0"
 				break
 			} else if err != nil {
 				return "", microerror.Mask(err)

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -3,6 +3,7 @@ package gitrepo
 import (
 	"context"
 	"io"
+	"regexp"
 	"strings"
 
 	"github.com/giantswarm/microerror"
@@ -16,6 +17,8 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing/transport/http"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
 )
+
+var tagRegex = regexp.MustCompile(`^v?[0-9]+\.[0-9]+\.[0-9]+`)
 
 type Config struct {
 	AuthBasicToken string
@@ -113,7 +116,9 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 			} else if err != nil {
 				return "", microerror.Mask(err)
 			}
-			tags[tag.Hash().String()] = tag.Name().Short()
+			if tagRegex.MatchString(tag.Name().Short()) {
+				tags[tag.Hash().String()] = tag.Name().Short()
+			}
 		}
 	}
 

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -117,7 +117,7 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 				return "", microerror.Mask(err)
 			}
 			if tagRegex.MatchString(tag.Name().Short()) {
-				tags[tag.Hash().String()] = tag.Name().Short()
+				tags[tag.Hash().String()] = strings.TrimPrefix(strings.TrimSpace(tag.Name().Short()), "v")
 			}
 		}
 	}
@@ -154,7 +154,7 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 		for {
 			tag, ok := tags[c.Hash.String()]
 			if ok {
-				lastTag = strings.TrimPrefix(strings.TrimSpace(tag), "v")
+				lastTag = tag
 				break
 			}
 			c, err = c.Parent(0)


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/6844

This PR add filtering to only return version for semver tags and strip the `v` prefix from tags.