### PR TITLE
gitrepo: default URL for cloned repositories

### DIFF
--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -67,12 +67,14 @@ func New(config Config) (*Repo, error) {
 			return nil, microerror.Maskf(invalidConfigError, "%T.URL not set and failed to find remote with name %#q with error %#q", config, remoteName, err)
 		}
 
-		urls := remote.Config().URLs
-		if len(urls) == 0 || urls[0] == "" {
-			return nil, microerror.Maskf(invalidConfigError, "%T.URL not set and failed to %#q remote does not have set URLs", config, remoteName)
-		}
-
-		config.URL = urls[0]
+		// According to
+		// https://godoc.org/gopkg.in/src-d/go-git.v4/config#RemoteConfig:
+		//
+		//	URLs the URLs of a remote repository. It must be
+		//	non-empty. Fetch will always use the first URL, while
+		//	push will use all of them.
+		//
+		config.URL = remote.Config().URLs[0]
 	}
 
 	r := &Repo{

--- a/pkg/gitrepo/repo_test.go
+++ b/pkg/gitrepo/repo_test.go
@@ -5,14 +5,62 @@ import (
 	"os"
 	"strconv"
 	"testing"
+
+	"github.com/giantswarm/microerror"
 )
 
-// TestResolveVersion tests ResolveVersion method which resolve a git reference
+// Test_New_optionalURL tests if proper URL from origin branch is taken from
+// existing repository if none is specified.
+func Test_New_optionalURL(t *testing.T) {
+	ctx := context.Background()
+
+	dir := "/tmp/gitrepo-test-new-optionalurl"
+	defer os.RemoveAll(dir)
+
+	url := "git@github.com:giantswarm/gitrepo-test.git"
+
+	// Clone the repo first.
+	{
+		c := Config{
+			Dir: dir,
+			URL: "git@github.com:giantswarm/gitrepo-test.git",
+		}
+
+		repo, err := New(c)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = repo.EnsureUpToDate(ctx)
+		if err != nil {
+			t.Fatalf("err = %v, want = %v", microerror.Stack(err), nil)
+		}
+	}
+
+	// Open the repo without specifying URL and check if it is set
+	// properly.
+	{
+		c := Config{
+			Dir: dir,
+		}
+
+		repo, err := New(c)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if repo.url != url {
+			t.Fatalf("repo.url = %#q, want %#q", repo.url, url)
+		}
+	}
+}
+
+// Test_ResolveVersion tests ResolveVersion method which resolve a git reference
 // and find the project version for it. Tested repository can be found here:
 //
 //	https://github.com/giantswarm/gitrepo-test.
 //
-func TestResolveVersion(t *testing.T) {
+func Test_ResolveVersion(t *testing.T) {
 	testCases := []struct {
 		name            string
 		inputRef        string
@@ -70,7 +118,7 @@ func TestResolveVersion(t *testing.T) {
 		},
 	}
 
-	dir := "/tmp/gitrepo-test"
+	dir := "/tmp/gitrepo-test-resolveversion"
 	defer os.RemoveAll(dir)
 
 	c := Config{


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7491

This is handy in architect which operates on already cloned repositories
by the CI.