### PR TITLE
gitrepo: add TopLevel function

### DIFF
--- a/pkg/gitrepo/error.go
+++ b/pkg/gitrepo/error.go
@@ -2,6 +2,18 @@ package gitrepo
 
 import "github.com/giantswarm/microerror"
 
+// executionFailedError is an error type for situations where Resource execution
+// cannot continue and must always fall back to operatorkit.
+//
+// This error should never be matched against and therefore there is no matcher
+// implement. For further information see:
+//
+//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
+//
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",
 }

--- a/pkg/gitrepo/funcs.go
+++ b/pkg/gitrepo/funcs.go
@@ -1,0 +1,49 @@
+package gitrepo
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/giantswarm/microerror"
+)
+
+// Toplevel shows the absolute path of the top-level directory. The output
+// is the same as:
+//
+//	git rev-parse --show-toplevel
+//
+func TopLevel(ctx context.Context, path string) (string, error) {
+	p, err := filepath.Abs(path)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	f, err := os.Stat(p)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	if !f.IsDir() {
+		p = filepath.Dir(p)
+	}
+
+	for {
+		f, err := os.Stat(filepath.Join(p, ".git"))
+		if os.IsNotExist(err) {
+			// Fall trough.
+		} else if err != nil {
+			return "", microerror.Mask(err)
+		} else if f.IsDir() {
+			return p, nil
+		}
+
+		d := filepath.Dir(p)
+		if p == d {
+			break
+		}
+
+		p = d
+	}
+
+	return "", microerror.Maskf(executionFailedError, "path %#q is not inside git repository", path)
+}

--- a/pkg/gitrepo/funcs_test.go
+++ b/pkg/gitrepo/funcs_test.go
@@ -1,0 +1,70 @@
+package gitrepo
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/giantswarm/microerror"
+)
+
+func Test_TopLevel(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                string
+		inputPath           string
+		expectedRelativeDir string
+	}{
+		{
+			name:                "case 0",
+			inputPath:           ".",
+			expectedRelativeDir: "../..",
+		},
+		{
+			name:                "case 1",
+			inputPath:           "./repo.go",
+			expectedRelativeDir: "../..",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Log(tc.name)
+
+			ctx := context.Background()
+
+			abs, err := filepath.Abs(".")
+			if err != nil {
+				t.Fatalf("err = %v, want %v", microerror.Stack(err), nil)
+			}
+
+			expectedDir := filepath.Clean(filepath.Join(abs, tc.expectedRelativeDir))
+
+			// Check with relative path.
+			{
+				dir, err := TopLevel(ctx, tc.inputPath)
+				if err != nil {
+					t.Fatalf("err = %v, want %v", microerror.Stack(err), nil)
+				}
+
+				if dir != expectedDir {
+					t.Fatalf("dir = %v, want %v", dir, expectedDir)
+				}
+			}
+
+			// Check with absolute path.
+			{
+				dir, err := TopLevel(ctx, filepath.Join(abs, tc.inputPath))
+				if err != nil {
+					t.Fatalf("err = %v, want %v", microerror.Stack(err), nil)
+				}
+
+				if dir != expectedDir {
+					t.Fatalf("dir = %v, want %v", dir, expectedDir)
+				}
+			}
+		})
+	}
+}

--- a/pkg/gitrepo/repo_test.go
+++ b/pkg/gitrepo/repo_test.go
@@ -12,6 +12,8 @@ import (
 // Test_New_optionalURL tests if proper URL from origin branch is taken from
 // existing repository if none is specified.
 func Test_New_optionalURL(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	dir := "/tmp/gitrepo-test-new-optionalurl"
@@ -61,6 +63,8 @@ func Test_New_optionalURL(t *testing.T) {
 //	https://github.com/giantswarm/gitrepo-test.
 //
 func Test_ResolveVersion(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name            string
 		inputRef        string


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7491.

This is useful for `architect` to create instance of `Repo`. This allows it to figure out the top level git directory and then pass it as `Config.Dir`.