### PR TITLE
gitrepo: add Repo.Head{Branch,SHA,Tag} methods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/giantswarm/microerror v0.0.0-20190815145748-cb07ec533b50
 	github.com/go-errors/errors v1.0.1
 	github.com/juju/errgo v0.0.0-20140925100237-08cceb5d0b53 // indirect
+	golang.org/x/net v0.0.0-20191112182307-2180aed22343 // indirect
 	gopkg.in/src-d/go-billy.v4 v4.3.2
 	gopkg.in/src-d/go-git.v4 v4.13.1
 )

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 h1:Ao/3l156eZf2AW5wK8a7/smtodRU+gha3+BeqJ69lRk=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191112182307-2180aed22343 h1:00ohfJ4K98s3m6BGUoBd8nyfp4Yl0GoIKvw5abItTjI=
+golang.org/x/net v0.0.0-20191112182307-2180aed22343/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190221075227-b4e8571b14e0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/gitrepo/error.go
+++ b/pkg/gitrepo/error.go
@@ -22,3 +22,12 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -2,7 +2,6 @@ package gitrepo
 
 import (
 	"context"
-	"io"
 	"regexp"
 	"sort"
 	"strings"
@@ -119,30 +118,92 @@ func (r *Repo) EnsureUpToDate(ctx context.Context) error {
 	return nil
 }
 
+func (r *Repo) HeadBranch(ctx context.Context) (string, error) {
+	repo, err := git.Open(r.storage, nil)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	head, err := repo.Head()
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return head.Name().Short(), nil
+}
+
+func (r *Repo) HeadSHA(ctx context.Context) (string, error) {
+	repo, err := git.Open(r.storage, nil)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	head, err := repo.Head()
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return head.Hash().String(), nil
+}
+
+// HeadTag returns the tag for the HEAD ref.
+//
+// It returns error handled by IsNotFound if the HEAD ref is not tagged.
+func (r *Repo) HeadTag(ctx context.Context) (string, error) {
+	repo, err := git.Open(r.storage, nil)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	head, err := repo.Head()
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	tagsBySHA, err := r.tags(repo)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	tags := tagsBySHA[head.Hash().String()]
+
+	if len(tags) == 0 {
+		return "", microerror.Maskf(notFoundError, "HEAD ref is not tagged")
+	}
+	if len(tags) > 1 {
+		return "", microerror.Maskf(executionFailedError, "HEAD ref has multiple tags %v", tags)
+	}
+
+	return tags[0], nil
+}
+
 func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 	repo, err := git.Open(r.storage, nil)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}
 
-	tags := map[string]string{}
+	versionsByHash := map[string]string{}
 	{
-		tagsIter, err := repo.Tags()
+
+		tagsByHash, err := r.tags(repo)
 		if err != nil {
 			return "", microerror.Mask(err)
 		}
-		defer tagsIter.Close()
-		for {
-			tag, err := tagsIter.Next()
-			if errors.Is(err, io.EOF) {
-				break
-			} else if err != nil {
-				return "", microerror.Mask(err)
-			}
-			if tagRegex.MatchString(tag.Name().Short()) {
-				tags[tag.Hash().String()] = strings.TrimPrefix(strings.TrimSpace(tag.Name().Short()), "v")
+		for hash, tags := range tagsByHash {
+			for _, t := range tags {
+				var versionTags []string
+				if tagRegex.MatchString(t) {
+					versionTags = append(versionTags, t)
+					versionsByHash[hash] = strings.TrimPrefix(t, "v")
+				}
+
+				if len(versionTags) > 1 {
+					return "", microerror.Maskf(executionFailedError, "multiple version tags %#v found for hash %#q", versionTags, hash)
+				}
 			}
 		}
+
 	}
 
 	var commit *object.Commit
@@ -162,16 +223,18 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 	}
 
 	// When the commit is tagged return the tag.
-	tag, ok := tags[commit.Hash.String()]
-	if ok {
-		return tag, nil
+	{
+		version, ok := versionsByHash[commit.Hash.String()]
+		if ok {
+			return version, nil
+		}
 	}
 
 	// Otherwise find the first tagged parent and return it's tag glued
 	// with the SHA.
-	var version string
+	var pseudoVersion string
 	{
-		var lastTag string
+		var lastVersion string
 
 		queue := []*object.Commit{
 			commit,
@@ -179,7 +242,7 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 
 		for {
 			if len(queue) == 0 {
-				lastTag = "0.0.0"
+				lastVersion = "0.0.0"
 				break
 			}
 
@@ -189,9 +252,9 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 
 			// Check if this commit is tagged. If so the most
 			// recent tag is found and loop should be finished.
-			tag, ok := tags[c.Hash.String()]
+			v, ok := versionsByHash[c.Hash.String()]
 			if ok {
-				lastTag = tag
+				lastVersion = v
 				break
 			}
 
@@ -206,10 +269,34 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 			sort.Sort(commitSlice(queue))
 		}
 
-		version = lastTag + "-" + commit.Hash.String()
+		pseudoVersion = lastVersion + "-" + commit.Hash.String()
 	}
 
-	return version, nil
+	return pseudoVersion, nil
+}
+
+func (r *Repo) tags(repo *git.Repository) (map[string][]string, error) {
+	tagsIter, err := repo.Tags()
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	defer tagsIter.Close()
+
+	tags := map[string][]string{}
+
+	tagsIter.ForEach(func(tag *plumbing.Reference) error {
+		v := tags[tag.Hash().String()]
+		if v == nil {
+			v = []string{}
+		}
+		v = append(v, tag.Name().Short())
+
+		tags[tag.Hash().String()] = v
+
+		return nil
+	})
+
+	return tags, nil
 }
 
 type commitSlice []*object.Commit


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7491.

Needed to replace using git binary in architect pre hook
https://github.com/giantswarm/architect/blob/master/cmd/hook/preRunE.go#L14-L44.