### PR TITLE
gitrepo: don't fallback to origin when resolving version

### DIFF
--- a/pkg/gitrepo/error.go
+++ b/pkg/gitrepo/error.go
@@ -23,11 +23,11 @@ func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
 
-var notFoundError = &microerror.Error{
-	Kind: "notFoundError",
+var referenceNotFoundError = &microerror.Error{
+	Kind: "referenceNotFoundError",
 }
 
-// IsNotFound asserts notFoundError.
-func IsNotFound(err error) bool {
-	return microerror.Cause(err) == notFoundError
+// IsReferenceNotFound asserts referenceNotFoundError.
+func IsReferenceNotFound(err error) bool {
+	return microerror.Cause(err) == referenceNotFoundError
 }

--- a/pkg/gitrepo/repo_test.go
+++ b/pkg/gitrepo/repo_test.go
@@ -288,12 +288,6 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 				}
 			}
 
-			h, err := repo.HeadSHA(context.Background())
-			if err != nil {
-				t.Fatalf("err = %v, want %v", microerror.Stack(err), nil)
-			}
-			t.Logf("head=%s", h)
-
 			doneCh := make(chan struct{})
 			go func() {
 				version, err = repo.ResolveVersion(ctx, tc.inputRef)

--- a/pkg/gitrepo/repo_test.go
+++ b/pkg/gitrepo/repo_test.go
@@ -69,6 +69,7 @@ func Test_Repo_Head(t *testing.T) {
 	var err error
 
 	dir := "/tmp/gitrepo-test-repo-headbranch"
+	defer os.RemoveAll(dir)
 
 	// Checkout the gitrepo-test repository.
 	var repo *Repo
@@ -125,8 +126,8 @@ func Test_Repo_Head(t *testing.T) {
 	// Test HeadTag.
 	{
 		_, err := repo.HeadTag(ctx)
-		if !IsNotFound(err) {
-			t.Fatalf("err = %v, want %v", err, notFoundError)
+		if !IsReferenceNotFound(err) {
+			t.Fatalf("err = %v, want %v", err, referenceNotFoundError)
 		}
 
 		// Create "test-tag" tag on HEAD.
@@ -163,64 +164,91 @@ func Test_Repo_Head(t *testing.T) {
 func Test_Repo_ResolveVersion(t *testing.T) {
 	t.Parallel()
 
+	const masterTarget = "ref: refs/heads/master"
+
 	testCases := []struct {
 		name            string
+		inputHeadTarget string
 		inputRef        string
 		expectedVersion string
+		errorMatcher    func(err error) bool
 	}{
 		{
 			name:            "case 0: version tag",
+			inputHeadTarget: masterTarget,
 			inputRef:        "v1.0.0",
 			expectedVersion: "1.0.0",
 		},
 		{
 			name:            "case 1: another version tag",
+			inputHeadTarget: masterTarget,
 			inputRef:        "v2.0.0",
 			expectedVersion: "2.0.0",
 		},
 		{
 			name:            "case 2: tagged commit",
+			inputHeadTarget: masterTarget,
 			inputRef:        "02995edb3e6f14b8f9a83b84e3b8c7c8d9f60f86",
 			expectedVersion: "1.0.0",
 		},
 		{
 			name:            "case 3: another tagged commit",
+			inputHeadTarget: masterTarget,
 			inputRef:        "22b04802cd5ee933de078344fa53a3e37b826913",
 			expectedVersion: "2.0.0",
 		},
 		{
 			name:            "case 4: untagged commit without tagged parent",
+			inputHeadTarget: masterTarget,
 			inputRef:        "2091354c7b8659f1846a876fbe2032fd1390d569",
 			expectedVersion: "0.0.0-2091354c7b8659f1846a876fbe2032fd1390d569",
 		},
 		{
-			name:            "case 5: untagged commit with single tagged parent",
+			name:            "case 5: untagged commit without tagged parent with detached head",
+			inputHeadTarget: "2091354c7b8659f1846a876fbe2032fd1390d569",
+			inputRef:        "HEAD",
+			expectedVersion: "0.0.0-2091354c7b8659f1846a876fbe2032fd1390d569",
+		},
+		{
+			name:            "case 6: untagged commit with single tagged parent",
+			inputHeadTarget: masterTarget,
 			inputRef:        "5ff7013b7a5f43d39b8da62361cfbfd4d3bf9a50",
 			expectedVersion: "1.0.0-5ff7013b7a5f43d39b8da62361cfbfd4d3bf9a50",
 		},
 		{
-			name:            "case 6: another untagged commit with single tagged parent",
+			name:            "case 7: another untagged commit with single tagged parent",
+			inputHeadTarget: masterTarget,
 			inputRef:        "0c57573cece531f840a167aa0ccc29b178b6de42",
 			expectedVersion: "2.0.0-0c57573cece531f840a167aa0ccc29b178b6de42",
 		},
 		{
-			name:            "case 7: untagged commit with multiple tagged parents",
+			name:            "case 8: untagged commit with multiple tagged parents",
+			inputHeadTarget: masterTarget,
 			inputRef:        "c3726de44a2bb1bd898fdbe5632a90841636fa82",
 			expectedVersion: "2.0.0-c3726de44a2bb1bd898fdbe5632a90841636fa82",
 		},
 		{
-			name:            "case 8: untagged branch with single tagged parent",
-			inputRef:        "branch-of-2.0.0",
+			name:            "case 9: untagged branch with single tagged parent",
+			inputHeadTarget: masterTarget,
+			inputRef:        "origin/branch-of-2.0.0",
 			expectedVersion: "2.0.0-3901da4b6b4cf68e3d11a10f60916107828fa9a7",
 		},
 		{
-			name:            "case 9: untagged branch with multiple tagged parents",
-			inputRef:        "branch-of-1.0.0",
+			name:            "case 10: untagged branch with multiple tagged parents",
+			inputHeadTarget: masterTarget,
+			inputRef:        "origin/branch-of-1.0.0",
 			expectedVersion: "2.0.0-c3726de44a2bb1bd898fdbe5632a90841636fa82",
 		},
 		{
-			name:            "case 10: resolving complex tree with multiple common parents and long history",
-			inputRef:        "complex-tree",
+			name:            "case 11: unknown reference",
+			inputHeadTarget: masterTarget,
+			inputRef:        "branch-of-1.0.0",
+			errorMatcher:    IsReferenceNotFound,
+		},
+		{
+			name:            "case 12: resolving complex tree with multiple common parents and long history",
+			inputHeadTarget: masterTarget,
+			inputRef:        "origin/complex-tree",
 			expectedVersion: "0.0.0-a42e026e60b4c191ffb29430f439ad4b3aced71b",
 		},
 	}
@@ -251,6 +279,21 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			var err error
 			var version string
 
+			// Set HEAD.
+			{
+				ref := plumbing.NewReferenceFromStrings(plumbing.HEAD.String(), tc.inputHeadTarget)
+				err := repo.storage.SetReference(ref)
+				if err != nil {
+					t.Fatalf("err = %v, want %v", microerror.Stack(err), nil)
+				}
+			}
+
+			h, err := repo.HeadSHA(context.Background())
+			if err != nil {
+				t.Fatalf("err = %v, want %v", microerror.Stack(err), nil)
+			}
+			t.Logf("head=%s", h)
+
 			doneCh := make(chan struct{})
 			go func() {
 				version, err = repo.ResolveVersion(ctx, tc.inputRef)
@@ -262,9 +305,17 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			case <-time.After(15 * time.Second):
 				t.Fatalf("timeout after %v", 15*time.Second)
 			case <-doneCh:
-				if err != nil {
-					t.Fatalf("err = %v, want %v", microerror.Stack(err), nil)
+				switch {
+				case err == nil && tc.errorMatcher == nil:
+					// correct; carry on
+				case err != nil && tc.errorMatcher == nil:
+					t.Fatalf("error == %#v, want nil", err)
+				case err == nil && tc.errorMatcher != nil:
+					t.Fatalf("error == nil, want non-nil")
+				case !tc.errorMatcher(err):
+					t.Fatalf("error == %#v, want matching", err)
 				}
+
 				if version != tc.expectedVersion {
 					t.Errorf("got %q, expected %q\n", version, tc.expectedVersion)
 				}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7678

There are also some corner cases defined and tested:

- Tested there is no fallback to resolve origin branches in ResolveVersion.
- Test resolving for the detached head.
- Test handling unknown reference.
- Renamed IsNotFound to IsReferenceNotFound
- referenceNotFoundError may be returned by ResolveVersion