### PR TITLE
release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2020-03-16
+
+### Added
+
+- Add `EnsureUpToDate`: fetches latest changes from remote.
+- Add `GetFileContent`: retrieves content of file.
+- Add `HeadBranch`: returns branch name for the HEAD ref.
+- Add `HeadSHA`: returns sha for the HEAD ref.
+- Add `HeadTag`: returns tag for the HEAD ref.
+- Add `ResolveVersion`: resolves version of a reference.
+- Add `TopLevel`: finds absolute path of top-level git directory.
+
+[Unreleased]: https://github.com/giantswarm/architect-orb/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/giantswarm/architect-orb/releases/tag/v0.1.0

--- a/pkg/gitrepo/funcs.go
+++ b/pkg/gitrepo/funcs.go
@@ -8,7 +8,7 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
-// Toplevel shows the absolute path of the top-level directory. The output
+// Toplevel finds absolute path of top-level git directory. The output
 // is the same as:
 //
 //	git rev-parse --show-toplevel

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -93,6 +93,7 @@ func New(config Config) (*Repo, error) {
 	return r, nil
 }
 
+// EnsureUpToDate fetches latest changes from remote.
 func (r *Repo) EnsureUpToDate(ctx context.Context) error {
 	cloneOpts := &git.CloneOptions{
 		Auth:       r.auth,
@@ -125,6 +126,7 @@ func (r *Repo) EnsureUpToDate(ctx context.Context) error {
 	return nil
 }
 
+// HeadBranch returns branch name for the HEAD ref.
 func (r *Repo) HeadBranch(ctx context.Context) (string, error) {
 	repo, err := git.Open(r.storage, r.worktree)
 	if err != nil {
@@ -139,6 +141,7 @@ func (r *Repo) HeadBranch(ctx context.Context) (string, error) {
 	return head.Name().Short(), nil
 }
 
+// HeadSHA returns sha for the HEAD ref.
 func (r *Repo) HeadSHA(ctx context.Context) (string, error) {
 	repo, err := git.Open(r.storage, r.worktree)
 	if err != nil {
@@ -153,7 +156,7 @@ func (r *Repo) HeadSHA(ctx context.Context) (string, error) {
 	return head.Hash().String(), nil
 }
 
-// HeadTag returns the tag for the HEAD ref.
+// HeadTag returns tag for the HEAD ref.
 //
 // It returns error handled by IsReferenceNotFound if the HEAD ref is not
 // tagged.


### PR DESCRIPTION
Towards: giantswarm/giantswarm#8632

Prepare `0.1.0` release.

* Add CHANGELOG.md
* Update comments for exported functions