### PR TITLE
release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - 2020-03-16
+## [0.1.1] - 2020-03-17
 
 ### Added
 
@@ -19,5 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `ResolveVersion`: resolves version of a reference.
 - Add `TopLevel`: finds absolute path of top-level git directory.
 
-[Unreleased]: https://github.com/giantswarm/architect-orb/compare/v0.1.0...HEAD
+## [0.1.0] - 2019-10-10
+
+### Added
+
+- Functions signature for `EnsureUpToDate` and `ResolveVersion`.
+
+[Unreleased]: https://github.com/giantswarm/architect-orb/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/giantswarm/architect-orb/releases/tag/v0.1.1
 [0.1.0]: https://github.com/giantswarm/architect-orb/releases/tag/v0.1.0


### PR DESCRIPTION
Towards: giantswarm/giantswarm#8632

Prepare `0.1.1` release.

There was an issue with the previous `0.1.0` release as it was already created on 2019-10-10, this release is still cached on golang proxy: https://sum.golang.org, therefore the new changes are not showing when doing `go get -u github.com/giantswarm/gitrepo@v0.1.0`.

After this PR is merged I'll release a new `v0.1.1` and tag the previous `v0.1.0` to keep track of it and mention no to use it.