### PR TITLE
Wrap go-git specific errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Introduce new `IsRepositoryNotFound` error matcher
+
 ## [0.1.1] - 2020-03-17
 
 ### Added

--- a/pkg/gitrepo/error.go
+++ b/pkg/gitrepo/error.go
@@ -40,3 +40,12 @@ var referenceNotFoundError = &microerror.Error{
 func IsReferenceNotFound(err error) bool {
 	return microerror.Cause(err) == referenceNotFoundError
 }
+
+var repositoryNotFoundError = &microerror.Error{
+	Kind: "repositoryNotFoundError",
+}
+
+// IsRepositoryNotFound asserts referenceNotFoundError.
+func IsRepositoryNotFound(err error) bool {
+	return microerror.Cause(err) == repositoryNotFoundError
+}

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -122,6 +122,10 @@ func (r *Repo) EnsureUpToDate(ctx context.Context) error {
 	if errors.Is(err, git.NoErrAlreadyUpToDate) {
 		// Fall through.
 	} else if errors.Is(err, transport.ErrRepositoryNotFound) {
+		// This could happen if the repository does not exist, but you already have the folder on the filesystem.
+		// In that case Fetch will be the first to realise that repo does not exist since Clone only performs an Open.
+		// Also, Clone creates the folder on the filesystem even if it fails so you end simulate the same situation when
+		// you call EnsureUpToDate more that once on the same non-existent repo.
 		return microerror.Maskf(repositoryNotFoundError, "%#q", r.url)
 	} else if err != nil {
 		return microerror.Mask(err)

--- a/pkg/gitrepo/repo_test.go
+++ b/pkg/gitrepo/repo_test.go
@@ -94,6 +94,14 @@ func Test_Repo_EnsureUpToDate_nosuchrepo(t *testing.T) {
 		}
 	}
 
+	// Ensure we get a repositoryNotFoundError when we don't have repo on the filesystem
+	err = repo.EnsureUpToDate(ctx)
+	if !IsRepositoryNotFound(err) {
+		t.Fatalf("err = %v, want %v", microerror.Stack(err), repositoryNotFoundError)
+	}
+
+	// Even if clone fails the first time, it's leaking the directory on the filesystem.
+	// Ensure we keep getting a repositoryNotFoundError once repo is on the filesystem.
 	err = repo.EnsureUpToDate(ctx)
 	if !IsRepositoryNotFound(err) {
 		t.Fatalf("err = %v, want %v", microerror.Stack(err), repositoryNotFoundError)


### PR DESCRIPTION
Wrap plumbing.ErrReferenceNotFound and transport.ErrRepositoryNotFound (go-git specific) so they do not leak to the consumers of gitrepo.