### PR TITLE
Add method to get folder contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `GetFolderContent`: fetches the contents of a folder.
+
 ## [0.1.2] - 2020-07-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `GetFolderContent`: fetches the contents of a folder.
+- Add `GetFolderContent` which fetches the contents of a folder.
 
 ## [0.1.2] - 2020-07-24
 

--- a/pkg/gitrepo/error.go
+++ b/pkg/gitrepo/error.go
@@ -32,6 +32,15 @@ func IsFileNotFound(err error) bool {
 	return microerror.Cause(err) == fileNotFoundError
 }
 
+var folderNotFoundError = &microerror.Error{
+	Kind: "folderNotFoundError",
+}
+
+// IsFolderNotFound asserts folderNotFoundError.
+func IsFolderNotFound(err error) bool {
+	return microerror.Cause(err) == folderNotFoundError
+}
+
 var referenceNotFoundError = &microerror.Error{
 	Kind: "referenceNotFoundError",
 }

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -377,8 +377,20 @@ func (r *Repo) checkoutRef(ref string) (*git.Worktree, error) {
 		} else if err != nil {
 			return nil, microerror.Mask(err)
 		}
+
+		head, err := repo.Head()
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		if head.Hash() == *hash {
+			// We're already at the right ref, no need to checkout
+			return worktree, nil
+		}
+
 		opt.Hash = *hash
 	}
+
 	err = worktree.Checkout(opt)
 	if err != nil {
 		return nil, microerror.Mask(err)

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -349,7 +349,7 @@ func (r *Repo) GetFolderContent(path, ref string) ([]os.FileInfo, error) {
 
 	files, err := worktree.Filesystem.ReadDir(path)
 	if os.IsNotExist(err) {
-		return nil, microerror.Maskf(fileNotFoundError, "%#q", path)
+		return nil, microerror.Maskf(folderNotFoundError, "%#q", path)
 	} else if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -319,6 +319,45 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 // GetFileContent retrieves content of file stored at path on version specified in ref.
 // When empty ref defaults to master branch.
 func (r *Repo) GetFileContent(path, ref string) ([]byte, error) {
+	worktree, err := r.checkoutRef(ref)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	file, err := worktree.Filesystem.Open(path)
+	if os.IsNotExist(err) {
+		return nil, microerror.Maskf(fileNotFoundError, "%#q", path)
+	} else if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	content, err := ioutil.ReadAll(file)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return content, nil
+}
+
+// GetFolderContent retrieves content of a folder stored at path on version specified in ref.
+// When empty ref defaults to master branch.
+func (r *Repo) GetFolderContent(path, ref string) ([]os.FileInfo, error) {
+	worktree, err := r.checkoutRef(ref)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	files, err := worktree.Filesystem.ReadDir(path)
+	if os.IsNotExist(err) {
+		return nil, microerror.Maskf(fileNotFoundError, "%#q", path)
+	} else if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return files, nil
+}
+
+func (r *Repo) checkoutRef(ref string) (*git.Worktree, error) {
 	repo, err := git.Open(r.storage, r.worktree)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -345,19 +384,7 @@ func (r *Repo) GetFileContent(path, ref string) ([]byte, error) {
 		return nil, microerror.Mask(err)
 	}
 
-	file, err := worktree.Filesystem.Open(path)
-	if os.IsNotExist(err) {
-		return nil, microerror.Maskf(fileNotFoundError, "%#q", path)
-	} else if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	content, err := ioutil.ReadAll(file)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	return content, nil
+	return worktree, nil
 }
 
 func (r *Repo) tags(repo *git.Repository) (map[string][]string, error) {

--- a/pkg/gitrepo/repo_test.go
+++ b/pkg/gitrepo/repo_test.go
@@ -515,8 +515,8 @@ func Test_Repo_GetFolderContent(t *testing.T) {
 		},
 		{
 			name:         "case 3: folder not found error",
-			path:         "non/existent/file/path",
-			errorMatcher: IsFileNotFound,
+			path:         "non/existent",
+			errorMatcher: IsFolderNotFound,
 		},
 		{
 			name:         "case 4: handle reference not found error",


### PR DESCRIPTION
* Adds new method
* Checkout repository only if we're currently on the wrong ref. This was making operations like `opsctl list installations` extremely slow.