### PR TITLE
Checkout repo on initial clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Reading files from default branch after calling `EnsureUpToDate` on empty repo
+
 ## [0.2.0] - 2021-01-15
 
 ### Added

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -101,6 +101,14 @@ func (r *Repo) EnsureUpToDate(ctx context.Context) error {
 		NoCheckout: true,
 	}
 
+	_, err := r.worktree.Stat("/")
+	if os.IsNotExist(err) {
+		// Repo is empty so perform an initial checkout
+		cloneOpts.NoCheckout = false
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
 	repo, err := git.Clone(r.storage, r.worktree, cloneOpts)
 	if errors.Is(err, git.ErrRepositoryAlreadyExists) {
 		repo, err = git.Open(r.storage, r.worktree)

--- a/pkg/gitrepo/repo_test.go
+++ b/pkg/gitrepo/repo_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -393,52 +394,57 @@ func Test_Repo_GetFileContent(t *testing.T) {
 			expected: "DCO",
 		},
 		{
-			name:     "case 1: get DCO file content on branch-of-2.0.0 branch",
+			name:     "case 1: get DCO file content on default branch (master)",
+			path:     "DCO",
+			expected: "DCO",
+			ref:      "master",
+		},
+		{
+			name:     "case 2: get DCO file content on branch-of-2.0.0 branch",
 			path:     "DCO",
 			expected: "DCO",
 			ref:      "origin/branch-of-2.0.0",
 		},
 		{
-			name:     "case 2: get DCO file content on v2.0.0 tag",
+			name:     "case 3: get DCO file content on v2.0.0 tag",
 			path:     "DCO",
 			expected: "DCO",
 			ref:      "v2.0.0",
 		},
 		{
-			name:         "case 3: handle file not found error",
+			name:         "case 4: handle file not found error",
 			path:         "non/existent/file/path",
 			errorMatcher: IsFileNotFound,
 		},
 		{
-			name:         "case 4: handle reference not found error",
+			name:         "case 5: handle reference not found error",
 			path:         "DCO",
 			ref:          "does-not-exist",
 			errorMatcher: IsReferenceNotFound,
 		},
 	}
 
-	dir := "/tmp/gitrepo-test-repo-getfilecontent"
-	defer os.RemoveAll(dir)
-
-	c := Config{
-		Dir: dir,
-		URL: "git@github.com:giantswarm/gitrepo-test.git",
-	}
-	repo, err := New(c)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ctx := context.Background()
-
-	err = repo.EnsureUpToDate(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Log(tc.name)
+
+			dir := fmt.Sprintf("/tmp/gitrepo-test-repo-getfilecontent-%d", i)
+			defer os.RemoveAll(dir)
+
+			c := Config{
+				Dir: dir,
+				URL: "https://github.com/giantswarm/gitrepo-test",
+			}
+			repo, err := New(c)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ctx := context.Background()
+			err = repo.EnsureUpToDate(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			content, err := repo.GetFileContent(tc.path, tc.ref)
 


### PR DESCRIPTION
Because of [this change](https://github.com/giantswarm/gitrepo/blob/master/pkg/gitrepo/repo.go#L386-L388) repo stays empty when we try to read a file/folder from the default branch cause Checkout is responsible for populating the folder with the actual contents. And that change was needed because Checkout is extremely slow and we don't want to do it on every operation if it's not needed.