### PR TITLE
Clean up after checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Clean after checkout of repo to avoid leaking of folders/files.
+
 ## [0.2.1] - 2021-01-21
 
 ### Fixed

--- a/go.sum
+++ b/go.sum
@@ -56,7 +56,6 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49N
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 h1:Ao/3l156eZf2AW5wK8a7/smtodRU+gha3+BeqJ69lRk=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191112182307-2180aed22343 h1:00ohfJ4K98s3m6BGUoBd8nyfp4Yl0GoIKvw5abItTjI=
 golang.org/x/net v0.0.0-20191112182307-2180aed22343/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -404,6 +404,11 @@ func (r *Repo) checkoutRef(ref string) (*git.Worktree, error) {
 		return nil, microerror.Mask(err)
 	}
 
+	err = worktree.Clean(&git.CleanOptions{Dir: true})
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
 	return worktree, nil
 }
 


### PR DESCRIPTION
Sometimes when switching between different branches the current implementation was leaking files (like folders) from the previous branch.