### PR TITLE
Support tag prefixes for mono repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for git tag prefixes in version calculation logics. If the `GS_GIT_TAG_PREFIX` environment variable
+  is set to e.g. `mymodule-a` then tags like `mymodule-a/v1.2.3` will be looked for in the history instead of the
+  normal semantic versioning tags, when the env var is not set (default). New tags will be generated in the same
+  format and with the same logic tho. For the above example, a few commits ahead of that tag the new version in
+  a test build would be: `1.2.3-<GIT_HASH>`. When on the tag itself, it would be: `1.2.3`. When no tag found with
+  the given prefix, then it would be: `0.0.0-<GIT_HASH>`. This replicates the original behaviour, just the tag
+  looked up for reference changes in the behaviour. This enables creating sort of mono repositories where multiple
+  modules, libraries or smaller projects are stored in a single repo that needs to be versioned separately.
+
 ## [0.2.4] - 2024-06-03
+
+### Changed
 
 - Dependency updates
 

--- a/Makefile.gen.go.mk
+++ b/Makefile.gen.go.mk
@@ -63,15 +63,15 @@ $(APPLICATION)-windows-amd64.exe: $(APPLICATION)-v$(VERSION)-windows-amd64.exe
 
 $(APPLICATION)-v$(VERSION)-%-amd64: $(SOURCES)
 	@echo "====> $@"
-	CGO_ENABLED=0 GOOS=$* GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $@ .
+	CGO_ENABLED=0 GOOS=$* GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $@ ./...
 
 $(APPLICATION)-v$(VERSION)-%-arm64: $(SOURCES)
 	@echo "====> $@"
-	CGO_ENABLED=0 GOOS=$* GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o $@ .
+	CGO_ENABLED=0 GOOS=$* GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o $@ ./...
 
 $(APPLICATION)-v$(VERSION)-windows-amd64.exe: $(SOURCES)
 	@echo "====> $@"
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $@ .
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $@ ./...
 
 .PHONY: install
 install: ## Install the application.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/giantswarm/gitrepo
 go 1.19
 
 require (
-	github.com/giantswarm/microerror v0.4.1
 	github.com/go-errors/errors v1.5.1
 	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/go-git/go-git/v5 v5.12.0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a h1:mATvB/9r/3gvcejNsXKSkQ6lcIaNec2nyfOdlTBR2lU=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/giantswarm/microerror v0.4.1 h1:WMiD7HQASoUA9lZzPlPK+erCEOJ0uT4cyo18VfCXHD0=
-github.com/giantswarm/microerror v0.4.1/go.mod h1:URFj0gFCmZihjya6saQCXxslBrgctXb4NsXYHB5JdrI=
 github.com/gliderlabs/ssh v0.3.7 h1:iV3Bqi942d9huXnzEF2Mt+CY9gLu8DNM4Obd+8bODRE=
 github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
 github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=

--- a/pkg/gitrepo/error.go
+++ b/pkg/gitrepo/error.go
@@ -1,59 +1,77 @@
 package gitrepo
 
-import "github.com/giantswarm/microerror"
+import (
+	"reflect"
+)
 
-// executionFailedError is an error type for situations where Resource execution
-// cannot continue and must always fall back to operatorkit.
-//
-// This error should never be matched against and therefore there is no matcher
-// implement. For further information see:
-//
-// https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
-var executionFailedError = &microerror.Error{
-	Kind: "executionFailedError",
+type executionFailedError struct {
+	message string
 }
 
-var invalidConfigError = &microerror.Error{
-	Kind: "invalidConfigError",
+func (e *executionFailedError) Error() string {
+	return "executionFailedError: " + e.message
 }
 
-// IsInvalidConfig asserts invalidConfigError.
-func IsInvalidConfig(err error) bool {
-	return microerror.Cause(err) == invalidConfigError
+func (e *executionFailedError) Is(target error) bool {
+	return reflect.TypeOf(target) == reflect.TypeOf(e)
 }
 
-var fileNotFoundError = &microerror.Error{
-	Kind: "fileNotFoundError",
+type invalidConfigError struct {
+	message string
 }
 
-// IsFileNotFound asserts fileNotFoundError.
-func IsFileNotFound(err error) bool {
-	return microerror.Cause(err) == fileNotFoundError
+func (e *invalidConfigError) Error() string {
+	return "invalidConfigError: " + e.message
 }
 
-var folderNotFoundError = &microerror.Error{
-	Kind: "folderNotFoundError",
+func (e *invalidConfigError) Is(target error) bool {
+	return reflect.TypeOf(target) == reflect.TypeOf(e)
 }
 
-// IsFolderNotFound asserts folderNotFoundError.
-func IsFolderNotFound(err error) bool {
-	return microerror.Cause(err) == folderNotFoundError
+type fileNotFoundError struct {
+	message string
 }
 
-var referenceNotFoundError = &microerror.Error{
-	Kind: "referenceNotFoundError",
+func (e *fileNotFoundError) Error() string {
+	return "fileNotFoundError: " + e.message
 }
 
-// IsReferenceNotFound asserts referenceNotFoundError.
-func IsReferenceNotFound(err error) bool {
-	return microerror.Cause(err) == referenceNotFoundError
+func (e *fileNotFoundError) Is(target error) bool {
+	return reflect.TypeOf(target) == reflect.TypeOf(e)
 }
 
-var repositoryNotFoundError = &microerror.Error{
-	Kind: "repositoryNotFoundError",
+type folderNotFoundError struct {
+	message string
 }
 
-// IsRepositoryNotFound asserts referenceNotFoundError.
-func IsRepositoryNotFound(err error) bool {
-	return microerror.Cause(err) == repositoryNotFoundError
+func (e *folderNotFoundError) Error() string {
+	return "folderNotFoundError: " + e.message
+}
+
+func (e *folderNotFoundError) Is(target error) bool {
+	return reflect.TypeOf(target) == reflect.TypeOf(e)
+}
+
+type referenceNotFoundError struct {
+	message string
+}
+
+func (e *referenceNotFoundError) Error() string {
+	return "referenceNotFoundError: " + e.message
+}
+
+func (e *referenceNotFoundError) Is(target error) bool {
+	return reflect.TypeOf(target) == reflect.TypeOf(e)
+}
+
+type repositoryNotFoundError struct {
+	message string
+}
+
+func (e *repositoryNotFoundError) Error() string {
+	return "repositoryNotFoundError: " + e.message
+}
+
+func (e *repositoryNotFoundError) Is(target error) bool {
+	return reflect.TypeOf(target) == reflect.TypeOf(e)
 }

--- a/pkg/gitrepo/error.go
+++ b/pkg/gitrepo/error.go
@@ -52,15 +52,15 @@ func (e *folderNotFoundError) Is(target error) bool {
 	return reflect.TypeOf(target) == reflect.TypeOf(e)
 }
 
-type referenceNotFoundError struct {
+type ReferenceNotFoundError struct {
 	message string
 }
 
-func (e *referenceNotFoundError) Error() string {
-	return "referenceNotFoundError: " + e.message
+func (e *ReferenceNotFoundError) Error() string {
+	return "ReferenceNotFoundError: " + e.message
 }
 
-func (e *referenceNotFoundError) Is(target error) bool {
+func (e *ReferenceNotFoundError) Is(target error) bool {
 	return reflect.TypeOf(target) == reflect.TypeOf(e)
 }
 

--- a/pkg/gitrepo/funcs.go
+++ b/pkg/gitrepo/funcs.go
@@ -2,25 +2,24 @@ package gitrepo
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/giantswarm/microerror"
 )
 
-// Toplevel finds absolute path of top-level git directory. The output
+// TopLevel Toplevel finds absolute path of top-level git directory. The output
 // is the same as:
 //
 // `git rev-parse --show-toplevel`
 func TopLevel(ctx context.Context, path string) (string, error) {
 	p, err := filepath.Abs(path)
 	if err != nil {
-		return "", microerror.Mask(err)
+		return "", err
 	}
 
 	f, err := os.Stat(p)
 	if err != nil {
-		return "", microerror.Mask(err)
+		return "", err
 	}
 	if !f.IsDir() {
 		p = filepath.Dir(p)
@@ -31,7 +30,7 @@ func TopLevel(ctx context.Context, path string) (string, error) {
 		if os.IsNotExist(err) {
 			// Fall trough.
 		} else if err != nil {
-			return "", microerror.Mask(err)
+			return "", err
 		} else if f.IsDir() {
 			return p, nil
 		}
@@ -44,5 +43,5 @@ func TopLevel(ctx context.Context, path string) (string, error) {
 		p = d
 	}
 
-	return "", microerror.Maskf(executionFailedError, "path %#q is not inside git repository", path)
+	return "", &executionFailedError{message: fmt.Sprintf("path %#q is not inside git repository", path)}
 }

--- a/pkg/gitrepo/funcs_test.go
+++ b/pkg/gitrepo/funcs_test.go
@@ -5,8 +5,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
-
-	"github.com/giantswarm/microerror"
 )
 
 func Test_TopLevel(t *testing.T) {
@@ -37,7 +35,7 @@ func Test_TopLevel(t *testing.T) {
 
 			abs, err := filepath.Abs(".")
 			if err != nil {
-				t.Fatalf("err = %v, want %v", microerror.JSON(err), nil)
+				t.Fatalf("err = %v, want %v", err, nil)
 			}
 
 			expectedDir := filepath.Clean(filepath.Join(abs, tc.expectedRelativeDir))
@@ -46,7 +44,7 @@ func Test_TopLevel(t *testing.T) {
 			{
 				dir, err := TopLevel(ctx, tc.inputPath)
 				if err != nil {
-					t.Fatalf("err = %v, want %v", microerror.JSON(err), nil)
+					t.Fatalf("err = %v, want %v", err, nil)
 				}
 
 				if dir != expectedDir {
@@ -58,7 +56,7 @@ func Test_TopLevel(t *testing.T) {
 			{
 				dir, err := TopLevel(ctx, filepath.Join(abs, tc.inputPath))
 				if err != nil {
-					t.Fatalf("err = %v, want %v", microerror.JSON(err), nil)
+					t.Fatalf("err = %v, want %v", err, nil)
 				}
 
 				if dir != expectedDir {

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -221,7 +221,7 @@ func (r *Repo) HeadTag(ctx context.Context) (string, error) {
 	}
 
 	if len(filteredTags) == 0 {
-		return "", &referenceNotFoundError{message: fmt.Sprintf("HEAD ref is not tagged (filtered for prefix: '%s')", tagPrefix)}
+		return "", &ReferenceNotFoundError{message: fmt.Sprintf("HEAD ref is not tagged (filtered for prefix: '%s')", tagPrefix)}
 	}
 	if len(filteredTags) > 1 {
 		return "", &executionFailedError{message: fmt.Sprintf("HEAD ref has multiple tags %v (filtered for prefix: '%s')", filteredTags, tagPrefix)}
@@ -287,7 +287,7 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 	{
 		hash, err := repo.ResolveRevision(plumbing.Revision(ref))
 		if errors.Is(err, plumbing.ErrReferenceNotFound) {
-			return "", &referenceNotFoundError{message: fmt.Sprintf("%#q", ref)}
+			return "", &ReferenceNotFoundError{message: fmt.Sprintf("%#q", ref)}
 		} else if err != nil {
 			return "", err
 		}
@@ -422,7 +422,7 @@ func (r *Repo) checkoutRef(ref string) (*git.Worktree, error) {
 	if ref != "" {
 		hash, err := repo.ResolveRevision(plumbing.Revision(ref))
 		if errors.Is(err, plumbing.ErrReferenceNotFound) {
-			return nil, &referenceNotFoundError{message: fmt.Sprintf("%#q", ref)}
+			return nil, &ReferenceNotFoundError{message: fmt.Sprintf("%#q", ref)}
 		} else if err != nil {
 			return nil, err
 		}

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -24,7 +24,7 @@ import (
 
 var tagRegex = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+`)
 
-var tagPrefixEnvVarName = "GS_TAG_PREFIX"
+var tagPrefixEnvVarName = "GS_GIT_TAG_PREFIX"
 var prefixedTagRegex = regexp.MustCompile(`^[a-zA-Z0-9-_]+/v[0-9]+\.[0-9]+\.[0-9]+`)
 
 type Config struct {

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -238,7 +238,7 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 				if tagPrefix != "" {
 					if prefixedTagRegex.MatchString(t) && strings.HasPrefix(t, tagPrefix+"/") {
 						versionTags = append(versionTags, t)
-						versionsByHash[hash] = strings.TrimPrefix(t, "v")
+						versionsByHash[hash] = strings.TrimPrefix(strings.TrimPrefix(t, tagPrefix+"/"), "v")
 					}
 				} else {
 					if tagRegex.MatchString(t) {

--- a/pkg/gitrepo/repo_test.go
+++ b/pkg/gitrepo/repo_test.go
@@ -305,7 +305,7 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 				tagPrefixEnvVarName: "module-c",
 			},
 			inputRef:        "ab61bc963b844551ffaf080f84d217e483323210",
-			expectedVersion: "module-c/v2.0.0",
+			expectedVersion: "2.0.0",
 		},
 		{
 			name:            "case 14: ...",
@@ -314,7 +314,7 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 				tagPrefixEnvVarName: "module-a",
 			},
 			inputRef:        "4707825fd7775c69fbd2f72a990e315b367b5409",
-			expectedVersion: "module-a/v0.1.1",
+			expectedVersion: "0.1.1",
 		},
 		{
 			name:            "case 15: ...",
@@ -323,7 +323,7 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 				tagPrefixEnvVarName: "module-c",
 			},
 			inputRef:        "4707825fd7775c69fbd2f72a990e315b367b5409",
-			expectedVersion: "module-c/v1.1.0",
+			expectedVersion: "1.1.0",
 		},
 		{
 			name:            "case 16: ...",
@@ -332,7 +332,31 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 				tagPrefixEnvVarName: "module-b",
 			},
 			inputRef:        "4707825fd7775c69fbd2f72a990e315b367b5409",
-			expectedVersion: "module-b/v0.2.0-4707825fd7775c69fbd2f72a990e315b367b5409",
+			expectedVersion: "0.2.0-4707825fd7775c69fbd2f72a990e315b367b5409",
+		},
+		{
+			name:            "case 17: ...",
+			inputHeadTarget: monorepoTarget,
+			environment: map[string]string{
+				tagPrefixEnvVarName: "module-not-exist",
+			},
+			inputRef:        "57aae3db71bcd176dd5a39eb8b487aae54930dcd",
+			expectedVersion: "0.0.0-57aae3db71bcd176dd5a39eb8b487aae54930dcd",
+		},
+		{
+			name:            "case 18: ...",
+			inputHeadTarget: monorepoTarget,
+			inputRef:        "ab61bc963b844551ffaf080f84d217e483323210",
+			expectedVersion: "2.0.0-ab61bc963b844551ffaf080f84d217e483323210",
+		},
+		{
+			name:            "case 19: ...",
+			inputHeadTarget: monorepoTarget,
+			inputRef:        "35d336b84623963eb4a9ea554b4ebf3f93a5d63d",
+			environment: map[string]string{
+				tagPrefixEnvVarName: "module-a",
+			},
+			expectedVersion: "0.0.0-35d336b84623963eb4a9ea554b4ebf3f93a5d63d",
 		},
 	}
 

--- a/pkg/gitrepo/repo_test.go
+++ b/pkg/gitrepo/repo_test.go
@@ -5,13 +5,14 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/go-errors/errors"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/go-errors/errors"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"

--- a/pkg/gitrepo/repo_test.go
+++ b/pkg/gitrepo/repo_test.go
@@ -172,8 +172,8 @@ func Test_Repo_Head(t *testing.T) {
 	// Test HeadTag (with multiple tags for modules as well).
 	{
 		_, err := repo.HeadTag(ctx)
-		if !errors.Is(err, &referenceNotFoundError{}) {
-			t.Fatalf("err = %v, want %v", err, referenceNotFoundError{})
+		if !errors.Is(err, &ReferenceNotFoundError{}) {
+			t.Fatalf("err = %v, want %v", err, ReferenceNotFoundError{})
 		}
 
 		// Create "test-tag" tag on HEAD.
@@ -335,7 +335,7 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			name:            "case 11: unknown reference",
 			inputHeadTarget: masterTarget,
 			inputRef:        "branch-of-1.0.0",
-			expectedError:   &referenceNotFoundError{},
+			expectedError:   &ReferenceNotFoundError{},
 		},
 		{
 			name:            "case 12: resolving complex tree with multiple common parents and long history",
@@ -528,7 +528,7 @@ func Test_Repo_GetFileContent(t *testing.T) {
 			name:          "case 5: handle reference not found error",
 			path:          "DCO",
 			ref:           "does-not-exist",
-			expectedError: &referenceNotFoundError{},
+			expectedError: &ReferenceNotFoundError{},
 		},
 	}
 
@@ -638,7 +638,7 @@ func Test_Repo_GetFolderContent(t *testing.T) {
 			name:          "case 4: handle reference not found error",
 			path:          "DCO",
 			ref:           "does-not-exist",
-			expectedError: &referenceNotFoundError{},
+			expectedError: &ReferenceNotFoundError{},
 		},
 	}
 


### PR DESCRIPTION
Changes project version calculation when `GS_TAG_PREFIX` is set. For example setting `GS_TAG_PREFIX=module-a` will look for tags like `module-a/v1.0.0` and the rest of the behaviour is the same. If not set, only the normal `v1.0.0` like tags will be considered.

Towards: https://github.com/giantswarm/roadmap/issues/3408

Related to: https://github.com/giantswarm/gitrepo-test/tree/monorepo