### PR TITLE
Make errors public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Errors have been made public
+
 ## [0.3.1] - 2025-01-21
 
 - Dependency updates

--- a/pkg/gitrepo/error.go
+++ b/pkg/gitrepo/error.go
@@ -4,51 +4,51 @@ import (
 	"reflect"
 )
 
-type executionFailedError struct {
+type ExecutionFailedError struct {
 	message string
 }
 
-func (e *executionFailedError) Error() string {
-	return "executionFailedError: " + e.message
+func (e *ExecutionFailedError) Error() string {
+	return "ExecutionFailedError: " + e.message
 }
 
-func (e *executionFailedError) Is(target error) bool {
+func (e *ExecutionFailedError) Is(target error) bool {
 	return reflect.TypeOf(target) == reflect.TypeOf(e)
 }
 
-type invalidConfigError struct {
+type InvalidConfigError struct {
 	message string
 }
 
-func (e *invalidConfigError) Error() string {
-	return "invalidConfigError: " + e.message
+func (e *InvalidConfigError) Error() string {
+	return "InvalidConfigError: " + e.message
 }
 
-func (e *invalidConfigError) Is(target error) bool {
+func (e *InvalidConfigError) Is(target error) bool {
 	return reflect.TypeOf(target) == reflect.TypeOf(e)
 }
 
-type fileNotFoundError struct {
+type FileNotFoundError struct {
 	message string
 }
 
-func (e *fileNotFoundError) Error() string {
+func (e *FileNotFoundError) Error() string {
 	return "fileNotFoundError: " + e.message
 }
 
-func (e *fileNotFoundError) Is(target error) bool {
+func (e *FileNotFoundError) Is(target error) bool {
 	return reflect.TypeOf(target) == reflect.TypeOf(e)
 }
 
-type folderNotFoundError struct {
+type FolderNotFoundError struct {
 	message string
 }
 
-func (e *folderNotFoundError) Error() string {
+func (e *FolderNotFoundError) Error() string {
 	return "folderNotFoundError: " + e.message
 }
 
-func (e *folderNotFoundError) Is(target error) bool {
+func (e *FolderNotFoundError) Is(target error) bool {
 	return reflect.TypeOf(target) == reflect.TypeOf(e)
 }
 
@@ -64,14 +64,14 @@ func (e *ReferenceNotFoundError) Is(target error) bool {
 	return reflect.TypeOf(target) == reflect.TypeOf(e)
 }
 
-type repositoryNotFoundError struct {
+type RepositoryNotFoundError struct {
 	message string
 }
 
-func (e *repositoryNotFoundError) Error() string {
+func (e *RepositoryNotFoundError) Error() string {
 	return "repositoryNotFoundError: " + e.message
 }
 
-func (e *repositoryNotFoundError) Is(target error) bool {
+func (e *RepositoryNotFoundError) Is(target error) bool {
 	return reflect.TypeOf(target) == reflect.TypeOf(e)
 }

--- a/pkg/gitrepo/funcs.go
+++ b/pkg/gitrepo/funcs.go
@@ -43,5 +43,5 @@ func TopLevel(ctx context.Context, path string) (string, error) {
 		p = d
 	}
 
-	return "", &executionFailedError{message: fmt.Sprintf("path %#q is not inside git repository", path)}
+	return "", &ExecutionFailedError{message: fmt.Sprintf("path %#q is not inside git repository", path)}
 }

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -43,7 +43,7 @@ type Repo struct {
 
 func New(config Config) (*Repo, error) {
 	if config.Dir == "" {
-		return nil, &invalidConfigError{message: fmt.Sprintf("%T.Dir must not be empty", config)}
+		return nil, &InvalidConfigError{message: fmt.Sprintf("%T.Dir must not be empty", config)}
 	}
 
 	var auth transport.AuthMethod
@@ -65,14 +65,14 @@ func New(config Config) (*Repo, error) {
 	if config.URL == "" {
 		repo, err := git.Open(storage, worktree)
 		if err != nil {
-			return nil, &invalidConfigError{message: fmt.Sprintf("%T.URL not set and failed to open repository with error %#q", config, err)}
+			return nil, &InvalidConfigError{message: fmt.Sprintf("%T.URL not set and failed to open repository with error %#q", config, err)}
 		}
 
 		remoteName := "origin"
 
 		remote, err := repo.Remote(remoteName)
 		if err != nil {
-			return nil, &invalidConfigError{message: fmt.Sprintf("%T.URL not set and failed to find remote with name %#q with error %#q", config, remoteName, err)}
+			return nil, &InvalidConfigError{message: fmt.Sprintf("%T.URL not set and failed to find remote with name %#q with error %#q", config, remoteName, err)}
 		}
 
 		// According to
@@ -119,7 +119,7 @@ func (r *Repo) EnsureUpToDate(ctx context.Context) error {
 			return err
 		}
 	} else if errors.Is(err, transport.ErrRepositoryNotFound) {
-		return &repositoryNotFoundError{message: fmt.Sprintf("%#q", r.url)}
+		return &RepositoryNotFoundError{message: fmt.Sprintf("%#q", r.url)}
 	} else if err != nil {
 		return err
 	}
@@ -137,7 +137,7 @@ func (r *Repo) EnsureUpToDate(ctx context.Context) error {
 		// In that case Fetch will be the first to realise that repo does not exist since Clone only performs an Open.
 		// Also, Clone creates the folder on the filesystem even if it fails, so you end simulate the same situation when
 		// you call EnsureUpToDate more that once on the same non-existent repo.
-		return &repositoryNotFoundError{message: fmt.Sprintf("%#q", r.url)}
+		return &RepositoryNotFoundError{message: fmt.Sprintf("%#q", r.url)}
 	} else if err != nil {
 		return err
 	}
@@ -224,7 +224,7 @@ func (r *Repo) HeadTag(ctx context.Context) (string, error) {
 		return "", &ReferenceNotFoundError{message: fmt.Sprintf("HEAD ref is not tagged (filtered for prefix: '%s')", tagPrefix)}
 	}
 	if len(filteredTags) > 1 {
-		return "", &executionFailedError{message: fmt.Sprintf("HEAD ref has multiple tags %v (filtered for prefix: '%s')", filteredTags, tagPrefix)}
+		return "", &ExecutionFailedError{message: fmt.Sprintf("HEAD ref has multiple tags %v (filtered for prefix: '%s')", filteredTags, tagPrefix)}
 	}
 
 	return filteredTags[0], nil
@@ -276,7 +276,7 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 				}
 
 				if len(versionTags) > 1 {
-					return "", &executionFailedError{message: fmt.Sprintf("multiple version tags %#v found for hash %#q", versionTags, hash)}
+					return "", &ExecutionFailedError{message: fmt.Sprintf("multiple version tags %#v found for hash %#q", versionTags, hash)}
 				}
 			}
 		}
@@ -375,7 +375,7 @@ func (r *Repo) GetFileContent(path, ref string) ([]byte, error) {
 
 	file, err := worktree.Filesystem.Open(path)
 	if os.IsNotExist(err) {
-		return nil, &fileNotFoundError{message: fmt.Sprintf("%#q", path)}
+		return nil, &FileNotFoundError{message: fmt.Sprintf("%#q", path)}
 	} else if err != nil {
 		return nil, err
 	}
@@ -398,7 +398,7 @@ func (r *Repo) GetFolderContent(path, ref string) ([]os.FileInfo, error) {
 
 	files, err := worktree.Filesystem.ReadDir(path)
 	if os.IsNotExist(err) {
-		return nil, &folderNotFoundError{message: fmt.Sprintf("%#q", path)}
+		return nil, &FolderNotFoundError{message: fmt.Sprintf("%#q", path)}
 	} else if err != nil {
 		return nil, err
 	}

--- a/pkg/gitrepo/repo_test.go
+++ b/pkg/gitrepo/repo_test.go
@@ -70,7 +70,7 @@ func Test_New_optionalURL(t *testing.T) {
 }
 
 // Test_Repo_EnsureUpToDate_nosuchrepo tests that EnsureUpToDate returns
-// a repositoryNotFoundError when the repo does not exist.
+// a RepositoryNotFoundError when the repo does not exist.
 func Test_Repo_EnsureUpToDate_nosuchrepo(t *testing.T) {
 	t.Parallel()
 
@@ -95,17 +95,17 @@ func Test_Repo_EnsureUpToDate_nosuchrepo(t *testing.T) {
 		}
 	}
 
-	// Ensure we get a repositoryNotFoundError when we don't have repo on the filesystem
+	// Ensure we get a RepositoryNotFoundError when we don't have repo on the filesystem
 	err = repo.EnsureUpToDate(ctx)
-	if !errors.Is(err, &repositoryNotFoundError{}) {
-		t.Fatalf("err = %v, want %v", err, repositoryNotFoundError{})
+	if !errors.Is(err, &RepositoryNotFoundError{}) {
+		t.Fatalf("err = %v, want %v", err, RepositoryNotFoundError{})
 	}
 
 	// Even if clone fails the first time, it's leaking the directory on the filesystem.
-	// Ensure we keep getting a repositoryNotFoundError once repo is on the filesystem.
+	// Ensure we keep getting a RepositoryNotFoundError once repo is on the filesystem.
 	err = repo.EnsureUpToDate(ctx)
-	if !errors.Is(err, &repositoryNotFoundError{}) {
-		t.Fatalf("err = %v, want %v", err, repositoryNotFoundError{})
+	if !errors.Is(err, &RepositoryNotFoundError{}) {
+		t.Fatalf("err = %v, want %v", err, RepositoryNotFoundError{})
 	}
 }
 
@@ -522,7 +522,7 @@ func Test_Repo_GetFileContent(t *testing.T) {
 		{
 			name:          "case 4: handle file not found error",
 			path:          "non/existent/file/path",
-			expectedError: &fileNotFoundError{},
+			expectedError: &FileNotFoundError{},
 		},
 		{
 			name:          "case 5: handle reference not found error",
@@ -632,7 +632,7 @@ func Test_Repo_GetFolderContent(t *testing.T) {
 		{
 			name:          "case 3: folder not found error",
 			path:          "non/existent",
-			expectedError: &folderNotFoundError{},
+			expectedError: &FolderNotFoundError{},
 		},
 		{
 			name:          "case 4: handle reference not found error",


### PR DESCRIPTION
Make errors public so we can work around v0.3 changes.
For instance, this would unblock this one: https://github.com/giantswarm/opsctl/pull/2244

`ReferenceNotFoundError` was already public, so this change aligns all errors.