### PR TITLE
New versioning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@6.15.0
+  architect: giantswarm/architect@8.2.2
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,16 @@ orbs:
 workflows:
   build:
     jobs:
+      - architect/go-test:
+          name: go-test
+          # Needed to trigger job also on git tag.
+          filters:
+            # Trigger job also on git tag.
+            tags:
+              only: /^v.*/
       - architect/go-build:
           binary: gitrepo-version
           architectures: "linux/amd64,linux/arm64"
           context: architect
+          requires:
+            - go-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,3 +8,4 @@ workflows:
       - architect/go-build:
           binary: gitrepo-version
           architectures: "linux/amd64,linux/arm64"
+          context: architect

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ workflows:
   build:
     jobs:
       - architect/go-test:
-          name: go-test
+          name: go-test-gitrepo
           # Needed to trigger job also on git tag.
           filters:
             # Trigger job also on git tag.
@@ -17,4 +17,4 @@ workflows:
           architectures: "linux/amd64,linux/arm64"
           context: architect
           requires:
-            - go-test
+            - go-test-gitrepo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,8 @@ orbs:
   architect: giantswarm/architect@6.15.0
 
 workflows:
-  go-build:
+  build:
     jobs:
-      - architect/go-test:
-          name: go-test-gitrepo
-          # Needed to trigger job also on git tag.
-          filters:
-            tags:
-              only: /^v.*/
+      - architect/go-build:
+          binary: gitrepo-version
+          architectures: "linux/amd64,linux/arm64"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-gitrepo-version
+/gitrepo-version

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+gitrepo-version

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,6 @@
+version: "2"
+
+linters:
+  settings:
+    goconst:
+      ignore-tests: true

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Library and CLI tool for computing a semVer-compatible version from a git refere
 |---|---|
 | HEAD carries stable tag `vX.Y.Z` | `X.Y.Z` |
 | HEAD carries pre-release tag `vX.Y.Z-rc.N` | `X.Y.Z-rc.N` |
-| HEAD is untagged, stable ancestor `vX.Y.Z` reachable | `X.Y.(Z+1)-dev.<branch>.<YYYYMMDD>.<HHMMSS>` |
-| HEAD is untagged, no stable ancestor reachable | `0.0.0-dev.<branch>.<YYYYMMDD>.<HHMMSS>` |
+| HEAD is untagged, stable ancestor `vX.Y.Z` reachable | `X.Y.(Z+1)-dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS>` |
+| HEAD is untagged, no stable ancestor reachable | `0.0.0-dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS>` |
 
 For untagged commits the base is the most recent **stable** ancestor tag reachable from the ref (RC and other pre-release tags are skipped). When no stable ancestor exists the version prefix is `0.0.0` with no patch increment.
 
@@ -40,7 +40,7 @@ Example — print the version for the current working tree:
 
 ```sh
 $ GS_BRANCH_NAME=my-feature gitrepo-version
-1.2.4-dev.my-feature.20260127.094959
+1.2.4-dev.my-feature.2026-01-27.09-49-59
 
 $ gitrepo-version --ref v1.2.3
 1.2.3
@@ -55,5 +55,5 @@ c := gitrepo.Config{
 }
 repo, err := gitrepo.New(c)
 version, err := repo.ResolveVersion(ctx, "HEAD")
-// e.g. "1.2.4-dev.my-feature.20260127.094959"
+// e.g. "1.2.4-dev.my-feature.2026-01-27.09-49-59"
 ```

--- a/README.md
+++ b/README.md
@@ -3,17 +3,56 @@
 
 # gitrepo
 
-This is a library used to compute a project version given a git reference.
+Library and CLI tool for computing a semVer-compatible version from a git reference.
 
-Here is how to use it:
+## Version format
+
+| Situation | Returned version |
+|---|---|
+| HEAD carries stable tag `vX.Y.Z` | `X.Y.Z` |
+| HEAD carries pre-release tag `vX.Y.Z-rc.N` | `X.Y.Z-rc.N` |
+| HEAD is untagged | `X.Y.(Z+1)-dev.<branch>.<YYYYMMDD>.<HHMMSS>` |
+
+For untagged commits the base `X.Y.Z` is the most recent **stable** ancestor tag reachable from the ref (RC and other pre-release tags are skipped). When no stable ancestor exists the base is `0.0.0`.
+
+## Environment variables
+
+| Variable | Effect |
+|---|---|
+| `GS_BRANCH_NAME` | Override the branch name embedded in dev build versions. Defaults to the HEAD branch of the repo, then `"unknown"`. |
+| `GS_GIT_TAG_PREFIX` | Monorepo support: only consider tags prefixed with `"<value>/"`, e.g. `module-a/v1.2.3`. |
+
+## CLI — `gitrepo-version`
+
+```
+go install github.com/giantswarm/gitrepo/cmd/gitrepo-version@latest
+```
+
+```
+Usage: gitrepo-version [flags]
+
+  -dir string   path inside the git repository (default ".", resolved to repo root)
+  -ref string   git ref to resolve: branch name, tag, or commit SHA (default "HEAD")
+```
+
+Example — print the version for the current working tree:
+
+```sh
+$ GS_BRANCH_NAME=my-feature gitrepo-version
+1.2.4-dev.my-feature.20260127.094959
+
+$ gitrepo-version --ref v1.2.3
+1.2.3
+```
+
+## Go library
 
 ```go
-c := Config{
-	AuthBasicToken: "github-token",
-	Dir:            "/path/to/some-repo",
-	URL:            "git@github.com:giantswarm/some-repo.git",
+c := gitrepo.Config{
+    Dir: "/path/to/some-repo",
+    URL: "git@github.com:giantswarm/some-repo.git",
 }
-repo, err := New(c)
-version, err := repo.ResolveVersion(ctx, "master")
-// version is 0.0.0-2e7604b8b3806b20ff305eb4e1a852c784ba34ca
+repo, err := gitrepo.New(c)
+version, err := repo.ResolveVersion(ctx, "HEAD")
+// e.g. "1.2.4-dev.my-feature.20260127.094959"
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For untagged commits the base `X.Y.Z` is the most recent **stable** ancestor tag
 ## CLI — `gitrepo-version`
 
 ```
-go install github.com/giantswarm/gitrepo/cmd/gitrepo-version@latest
+go install github.com/giantswarm/gitrepo@latest
 ```
 
 ```

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ Library and CLI tool for computing a semVer-compatible version from a git refere
 |---|---|
 | HEAD carries stable tag `vX.Y.Z` | `X.Y.Z` |
 | HEAD carries pre-release tag `vX.Y.Z-rc.N` | `X.Y.Z-rc.N` |
-| HEAD is untagged | `X.Y.(Z+1)-dev.<branch>.<YYYYMMDD>.<HHMMSS>` |
+| HEAD is untagged, stable ancestor `vX.Y.Z` reachable | `X.Y.(Z+1)-dev.<branch>.<YYYYMMDD>.<HHMMSS>` |
+| HEAD is untagged, no stable ancestor reachable | `0.0.0-dev.<branch>.<YYYYMMDD>.<HHMMSS>` |
 
-For untagged commits the base `X.Y.Z` is the most recent **stable** ancestor tag reachable from the ref (RC and other pre-release tags are skipped). When no stable ancestor exists the base is `0.0.0`.
+For untagged commits the base is the most recent **stable** ancestor tag reachable from the ref (RC and other pre-release tags are skipped). When no stable ancestor exists the version prefix is `0.0.0` with no patch increment.
 
 ## Environment variables
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@
 // For a pre-release tag (vX.Y.Z-rc.N) it prints X.Y.Z-rc.N.
 // For an untagged ref it prints a dev build:
 //
-//	X.Y.(Z+1)-dev.<branch>.<YYYYMMDD>.<HHMMSS>
+//	X.Y.(Z+1)-dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS>
 //
 // where X.Y.Z is the most recent stable ancestor tag reachable from the ref,
 // or 0.0.0 when none exists.

--- a/main.go
+++ b/main.go
@@ -1,0 +1,69 @@
+// gitrepo-version prints the semVer-compatible version for a git ref.
+//
+// For a ref that carries a stable tag (vX.Y.Z) it prints X.Y.Z.
+// For a pre-release tag (vX.Y.Z-rc.N) it prints X.Y.Z-rc.N.
+// For an untagged ref it prints a dev build:
+//
+//	X.Y.(Z+1)-dev.<branch>.<YYYYMMDD>.<HHMMSS>
+//
+// where X.Y.Z is the most recent stable ancestor tag reachable from the ref,
+// or 0.0.0 when none exists.
+//
+// Environment variables:
+//
+//	GS_BRANCH_NAME      Override the branch name embedded in dev builds.
+//	                    Defaults to the HEAD branch of the repo, then "unknown".
+//	GS_GIT_TAG_PREFIX   Monorepo support: only consider tags prefixed with
+//	                    "<value>/", e.g. "module-a/v1.2.3".
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/giantswarm/gitrepo/pkg/gitrepo"
+)
+
+func main() {
+	dir := flag.String("dir", ".", "path inside the git repository (resolved to the repo root)")
+	ref := flag.String("ref", "HEAD", "git ref to resolve: branch name, tag, or commit SHA")
+	flag.Parse()
+
+	if err := run(*dir, *ref); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(dir, ref string) error {
+	ctx := context.Background()
+
+	topLevel, err := gitrepo.TopLevel(ctx, dir)
+	if err != nil {
+		return fmt.Errorf("finding git root from %q: %w", dir, err)
+	}
+
+	repo, err := gitrepo.New(gitrepo.Config{Dir: topLevel})
+	if err != nil {
+		// New() fails when there is no origin remote and no URL was given.
+		// Fall back to a placeholder URL so we can still read local tags.
+		var invalidCfg *gitrepo.InvalidConfigError
+		if errors.As(err, &invalidCfg) {
+			repo, err = gitrepo.New(gitrepo.Config{Dir: topLevel, URL: "_"})
+		}
+		if err != nil {
+			return fmt.Errorf("opening repository at %q: %w", topLevel, err)
+		}
+	}
+
+	version, err := repo.ResolveVersion(ctx, ref)
+	if err != nil {
+		return fmt.Errorf("resolving version for %q: %w", ref, err)
+	}
+
+	fmt.Println(version)
+	return nil
+}

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -281,7 +281,7 @@ func (r *Repo) HeadTag(ctx context.Context) (string, error) {
 //   - Stable tag vX.Y.Z on the commit → returns "X.Y.Z"
 //   - Pre-release tag vX.Y.Z-<pre> on the commit → returns "X.Y.Z-<pre>" (e.g. "1.2.3-rc.1")
 //   - Untagged commit → returns a semVer dev build:
-//     "X.Y.(Z+1)-dev.<branch>.<YYYYMMDD>.<HHMMSS>"
+//     "X.Y.(Z+1)-dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS>"
 //     where X.Y.Z is the most recent stable (non-pre-release) ancestor tag reachable
 //     from the reference, or "0.0.0" when no stable ancestor exists. The branch name
 //     is resolved from GS_BRANCH_NAME env var, then the HEAD branch of the CWD git
@@ -429,8 +429,8 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 		pseudoVersion = fmt.Sprintf("%s-dev.%s.%s.%s",
 			base,
 			branch,
-			t.Format("20060102"),
-			t.Format("150405"),
+			t.Format("2006-01-02"),
+			t.Format("15-04-05"),
 		)
 	}
 

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -39,8 +39,6 @@ var branchSanitizeRegex = regexp.MustCompile(`[^a-zA-Z0-9-]+`)
 // nowFunc is the clock used for dev build timestamps; overridable in tests.
 var nowFunc = time.Now
 
-const unknownBranch = "unknown"
-
 // currentBranch returns the name of the branch to embed in dev build versions.
 // Priority: GS_BRANCH_NAME env var > HEAD branch of CWD git repo > "unknown".
 func currentBranch() string {
@@ -49,11 +47,11 @@ func currentBranch() string {
 	}
 	repo, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true})
 	if err != nil {
-		return unknownBranch
+		return "unknown"
 	}
 	head, err := repo.Head()
 	if err != nil {
-		return unknownBranch
+		return "unknown"
 	}
 	return head.Name().Short()
 }

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -376,12 +376,7 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 			commit,
 		}
 
-		for {
-			if len(queue) == 0 {
-				lastStableVersion = "0.0.0"
-				break
-			}
-
+		for len(queue) > 0 {
 			// Pop the first element from the queue.
 			c := queue[0]
 			queue = queue[1:]
@@ -420,9 +415,14 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 			sort.Slice(queue, func(i, j int) bool { return queue[i].Committer.When.After(queue[j].Committer.When) })
 		}
 
-		base, err := incrementPatch(lastStableVersion)
-		if err != nil {
-			return "", err
+		var base string
+		if lastStableVersion == "" {
+			base = "0.0.0"
+		} else {
+			base, err = incrementPatch(lastStableVersion)
+			if err != nil {
+				return "", err
+			}
 		}
 		branch := sanitizeBranchName(currentBranch())
 		t := nowFunc().UTC()

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -8,7 +8,9 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-errors/errors"
 	"github.com/go-git/go-billy/v5"
@@ -23,9 +25,52 @@ import (
 )
 
 var tagRegex = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+`)
+var stableTagRegex = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+$`)
 
 var tagPrefixEnvVarName = "GS_GIT_TAG_PREFIX"
 var prefixedTagRegex = regexp.MustCompile(`^[a-zA-Z0-9-_]+/v[0-9]+\.[0-9]+\.[0-9]+`)
+
+var branchEnvVarName = "GS_BRANCH_NAME"
+// branchSanitizeRegex replaces one or more consecutive invalid semVer
+// pre-release characters with a single hyphen.
+var branchSanitizeRegex = regexp.MustCompile(`[^a-zA-Z0-9-]+`)
+
+// nowFunc is the clock used for dev build timestamps; overridable in tests.
+var nowFunc = time.Now
+
+// currentBranch returns the name of the branch to embed in dev build versions.
+// Priority: GS_BRANCH_NAME env var > HEAD branch of CWD git repo > "unknown".
+func currentBranch() string {
+	if b := strings.TrimSpace(os.Getenv(branchEnvVarName)); b != "" {
+		return b
+	}
+	repo, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true})
+	if err != nil {
+		return "unknown"
+	}
+	head, err := repo.Head()
+	if err != nil {
+		return "unknown"
+	}
+	return head.Name().Short()
+}
+
+func sanitizeBranchName(branch string) string {
+	return branchSanitizeRegex.ReplaceAllString(branch, "-")
+}
+
+func incrementPatch(version string) (string, error) {
+	parts := strings.Split(version, ".")
+	if len(parts) != 3 {
+		return "", &ExecutionFailedError{message: fmt.Sprintf("invalid version %q: expected X.Y.Z", version)}
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return "", &ExecutionFailedError{message: fmt.Sprintf("invalid patch in version %q: %v", version, err)}
+	}
+	parts[2] = strconv.Itoa(patch + 1)
+	return strings.Join(parts, "."), nil
+}
 
 type Config struct {
 	AuthBasicToken string
@@ -230,20 +275,21 @@ func (r *Repo) HeadTag(ctx context.Context) (string, error) {
 	return filteredTags[0], nil
 }
 
-// ResolveVersion resolves version of a reference. It may be a version in
-// format "X.Y.Z" if the reference is tagged with tag in format "vX.Y.Z" (note
-// that the "v" prefix is trimmed). Otherwise, it will be a pseudo-version in
-// format "X.Y.Z-SHA" where "X.Y.Z" part is the value taken from the most
-// recent parent commit tagged with "vX.Y.Z" or "0.0.0" if no such parent exist
-// and "SHA" part is the git SHA of the given reference.
+// ResolveVersion resolves the version for a git reference:
 //
-// If GS_TAG_PREFIX environment variable is set, it looks for tag with prefixed with '<env_var_value>/'.
-// The second half of the tag must still be semantic versioned, e.g. 'module-a/v1.2.3'. The prefix, the separator
-// and the v prefix is removed from the returned result, similar to the default behaviour, e.g. for the example
-// it will return '1.2.3'. Git hash postfix for references after the last found tag works here just the same.q
+//   - Stable tag vX.Y.Z on the commit → returns "X.Y.Z"
+//   - Pre-release tag vX.Y.Z-<pre> on the commit → returns "X.Y.Z-<pre>" (e.g. "1.2.3-rc.1")
+//   - Untagged commit → returns a semVer dev build:
+//     "X.Y.(Z+1)-dev.<branch>.<YYYYMMDD>.<HHMMSS>"
+//     where X.Y.Z is the most recent stable (non-pre-release) ancestor tag reachable
+//     from the reference, or "0.0.0" when no stable ancestor exists. The branch name
+//     is resolved from GS_BRANCH_NAME env var, then the HEAD branch of the CWD git
+//     repo, then "unknown". Non-reachable tags are never used as the base.
 //
-// It returns error handled by IsReferenceNotFound if the HEAD ref is not
-// tagged.
+// If GS_GIT_TAG_PREFIX is set, only tags prefixed with "<value>/" are considered,
+// e.g. "module-a/v1.2.3". The prefix, separator, and "v" are stripped from the result.
+//
+// It returns an error handled by IsReferenceNotFound if the reference cannot be resolved.
 func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 	repo, err := git.Open(r.storage, r.worktree)
 	if err != nil {
@@ -253,6 +299,7 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 	tagPrefix := os.Getenv(tagPrefixEnvVarName)
 
 	versionsByHash := map[string]string{}
+	stableVersionsByHash := map[string]string{}
 	{
 
 		tagsByHash, err := r.tags(repo)
@@ -266,12 +313,21 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 				if tagPrefix != "" {
 					if prefixedTagRegex.MatchString(t) && strings.HasPrefix(t, tagPrefix+"/") {
 						versionTags = append(versionTags, t)
-						versionsByHash[hash] = strings.TrimPrefix(strings.TrimPrefix(t, tagPrefix+"/"), "v")
+						version := strings.TrimPrefix(strings.TrimPrefix(t, tagPrefix+"/"), "v")
+						versionsByHash[hash] = version
+						tagWithoutPrefix := strings.TrimPrefix(t, tagPrefix+"/")
+						if stableTagRegex.MatchString(tagWithoutPrefix) {
+							stableVersionsByHash[hash] = version
+						}
 					}
 				} else {
 					if tagRegex.MatchString(t) {
 						versionTags = append(versionTags, t)
-						versionsByHash[hash] = strings.TrimPrefix(t, "v")
+						version := strings.TrimPrefix(t, "v")
+						versionsByHash[hash] = version
+						if stableTagRegex.MatchString(t) {
+							stableVersionsByHash[hash] = version
+						}
 					}
 				}
 
@@ -306,11 +362,14 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 		}
 	}
 
-	// Otherwise find the first tagged parent and return it's tag glued
-	// with the SHA.
+	// Otherwise walk ancestors to find the most recent stable tagged parent,
+	// then return a semVer-compatible dev build version.
+	// The queue only ever holds commits reachable from `commit` (parents of parents,
+	// etc.), so stableVersionsByHash is only consulted for actual ancestors — tags
+	// on unrelated branches are never returned.
 	var pseudoVersion string
 	{
-		var lastVersion string
+		var lastStableVersion string
 
 		queue := []*object.Commit{
 			commit,
@@ -318,7 +377,7 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 
 		for {
 			if len(queue) == 0 {
-				lastVersion = "0.0.0"
+				lastStableVersion = "0.0.0"
 				break
 			}
 
@@ -326,11 +385,12 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 			c := queue[0]
 			queue = queue[1:]
 
-			// Check if this commit is tagged. If so the most
-			// recent tag is found and loop should be finished.
-			v, ok := versionsByHash[c.Hash.String()]
+			// Check if this commit has a stable tag. RC and other pre-release
+			// tags are intentionally skipped so the dev build base is always
+			// derived from the last stable release.
+			v, ok := stableVersionsByHash[c.Hash.String()]
 			if ok {
-				lastVersion = v
+				lastStableVersion = v
 				break
 			}
 
@@ -359,7 +419,18 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 			sort.Slice(queue, func(i, j int) bool { return queue[i].Committer.When.After(queue[j].Committer.When) })
 		}
 
-		pseudoVersion = lastVersion + "-" + commit.Hash.String()
+		base, err := incrementPatch(lastStableVersion)
+		if err != nil {
+			return "", err
+		}
+		branch := sanitizeBranchName(currentBranch())
+		t := nowFunc().UTC()
+		pseudoVersion = fmt.Sprintf("%s-dev.%s.%s.%s",
+			base,
+			branch,
+			t.Format("20060102"),
+			t.Format("150405"),
+		)
 	}
 
 	return pseudoVersion, nil

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -13,9 +13,9 @@ import (
 	"time"
 
 	"github.com/go-errors/errors"
-	"github.com/go-git/go-billy/v5"
+	billy "github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/osfs"
-	"github.com/go-git/go-git/v5"
+	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/cache"
 	"github.com/go-git/go-git/v5/plumbing/object"
@@ -31,12 +31,15 @@ var tagPrefixEnvVarName = "GS_GIT_TAG_PREFIX"
 var prefixedTagRegex = regexp.MustCompile(`^[a-zA-Z0-9-_]+/v[0-9]+\.[0-9]+\.[0-9]+`)
 
 var branchEnvVarName = "GS_BRANCH_NAME"
+
 // branchSanitizeRegex replaces one or more consecutive invalid semVer
 // pre-release characters with a single hyphen.
 var branchSanitizeRegex = regexp.MustCompile(`[^a-zA-Z0-9-]+`)
 
 // nowFunc is the clock used for dev build timestamps; overridable in tests.
 var nowFunc = time.Now
+
+const unknownBranch = "unknown"
 
 // currentBranch returns the name of the branch to embed in dev build versions.
 // Priority: GS_BRANCH_NAME env var > HEAD branch of CWD git repo > "unknown".
@@ -46,11 +49,11 @@ func currentBranch() string {
 	}
 	repo, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true})
 	if err != nil {
-		return "unknown"
+		return unknownBranch
 	}
 	head, err := repo.Head()
 	if err != nil {
-		return "unknown"
+		return unknownBranch
 	}
 	return head.Name().Short()
 }

--- a/pkg/gitrepo/repo.go
+++ b/pkg/gitrepo/repo.go
@@ -39,19 +39,21 @@ var branchSanitizeRegex = regexp.MustCompile(`[^a-zA-Z0-9-]+`)
 // nowFunc is the clock used for dev build timestamps; overridable in tests.
 var nowFunc = time.Now
 
+const unknownBranch = "unknown"
+
 // currentBranch returns the name of the branch to embed in dev build versions.
-// Priority: GS_BRANCH_NAME env var > HEAD branch of CWD git repo > "unknown".
+// Priority: GS_BRANCH_NAME env var > HEAD branch of CWD git repo > unknownBranch.
 func currentBranch() string {
 	if b := strings.TrimSpace(os.Getenv(branchEnvVarName)); b != "" {
 		return b
 	}
 	repo, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true})
 	if err != nil {
-		return "unknown"
+		return unknownBranch
 	}
 	head, err := repo.Head()
 	if err != nil {
-		return "unknown"
+		return unknownBranch
 	}
 	return head.Name().Short()
 }

--- a/pkg/gitrepo/repo_test.go
+++ b/pkg/gitrepo/repo_test.go
@@ -298,14 +298,14 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			inputHeadTarget: masterTarget,
 			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "2091354c7b8659f1846a876fbe2032fd1390d569",
-			expectedVersion: "0.0.1-dev.test-branch.20260127.094959",
+			expectedVersion: "0.0.0-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 5: untagged commit without tagged parent with detached head",
 			inputHeadTarget: "2091354c7b8659f1846a876fbe2032fd1390d569",
 			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "HEAD",
-			expectedVersion: "0.0.1-dev.test-branch.20260127.094959",
+			expectedVersion: "0.0.0-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 6: untagged commit with single tagged parent",
@@ -353,7 +353,7 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			inputHeadTarget: masterTarget,
 			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "origin/complex-tree",
-			expectedVersion: "0.0.1-dev.test-branch.20260127.094959",
+			expectedVersion: "0.0.0-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 13: ...",
@@ -400,7 +400,7 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 				branchEnvVarName:    "test-branch",
 			},
 			inputRef:        "57aae3db71bcd176dd5a39eb8b487aae54930dcd",
-			expectedVersion: "0.0.1-dev.test-branch.20260127.094959",
+			expectedVersion: "0.0.0-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 18: ...",
@@ -417,7 +417,7 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 				tagPrefixEnvVarName: "module-a",
 				branchEnvVarName:    "test-branch",
 			},
-			expectedVersion: "0.0.1-dev.test-branch.20260127.094959",
+			expectedVersion: "0.0.0-dev.test-branch.20260127.094959",
 		},
 	}
 

--- a/pkg/gitrepo/repo_test.go
+++ b/pkg/gitrepo/repo_test.go
@@ -22,18 +22,6 @@ import (
 
 var update = flag.Bool("update", false, "update .golden files")
 
-const (
-	testGitHubURL         = "git@github.com:giantswarm/gitrepo-test.git"
-	testTagV200           = "v2.0.0"
-	testVersion200        = "2.0.0"
-	testBranchName        = "test-branch"
-	testDevVersion001     = "0.0.1-dev.test-branch.20260127.094959"
-	testDevVersion201     = "2.0.1-dev.test-branch.20260127.094959"
-	testOriginBranchOf200 = "origin/branch-of-2.0.0"
-	testCommitSHA4707     = "4707825fd7775c69fbd2f72a990e315b367b5409"
-	testFileDCO           = "DCO"
-)
-
 // Test_New_optionalURL tests if proper URL from origin branch is taken from
 // existing repository if none is specified.
 func Test_New_optionalURL(t *testing.T) {
@@ -44,13 +32,13 @@ func Test_New_optionalURL(t *testing.T) {
 	dir := "/tmp/gitrepo-test-new-optionalurl"
 	defer func() { _ = os.RemoveAll(dir) }()
 
-	url := testGitHubURL
+	url := "git@github.com:giantswarm/gitrepo-test.git"
 
 	// Clone the repo first.
 	{
 		c := Config{
 			Dir: dir,
-			URL: testGitHubURL,
+			URL: "git@github.com:giantswarm/gitrepo-test.git",
 		}
 
 		repo, err := New(c)
@@ -137,7 +125,7 @@ func Test_Repo_Head(t *testing.T) {
 
 		c := Config{
 			Dir: dir,
-			URL: testGitHubURL,
+			URL: "git@github.com:giantswarm/gitrepo-test.git",
 		}
 		repo, err = New(c)
 		if err != nil {
@@ -290,8 +278,8 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 		{
 			name:            "case 1: another version tag",
 			inputHeadTarget: masterTarget,
-			inputRef:        testTagV200,
-			expectedVersion: testVersion200,
+			inputRef:        "v2.0.0",
+			expectedVersion: "2.0.0",
 		},
 		{
 			name:            "case 2: tagged commit",
@@ -303,56 +291,56 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			name:            "case 3: another tagged commit",
 			inputHeadTarget: masterTarget,
 			inputRef:        "22b04802cd5ee933de078344fa53a3e37b826913",
-			expectedVersion: testVersion200,
+			expectedVersion: "2.0.0",
 		},
 		{
 			name:            "case 4: untagged commit without tagged parent",
 			inputHeadTarget: masterTarget,
-			environment:     map[string]string{branchEnvVarName: testBranchName},
+			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "2091354c7b8659f1846a876fbe2032fd1390d569",
-			expectedVersion: testDevVersion001,
+			expectedVersion: "0.0.1-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 5: untagged commit without tagged parent with detached head",
 			inputHeadTarget: "2091354c7b8659f1846a876fbe2032fd1390d569",
-			environment:     map[string]string{branchEnvVarName: testBranchName},
+			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "HEAD",
-			expectedVersion: testDevVersion001,
+			expectedVersion: "0.0.1-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 6: untagged commit with single tagged parent",
 			inputHeadTarget: masterTarget,
-			environment:     map[string]string{branchEnvVarName: testBranchName},
+			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "5ff7013b7a5f43d39b8da62361cfbfd4d3bf9a50",
 			expectedVersion: "1.0.1-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 7: another untagged commit with single tagged parent",
 			inputHeadTarget: masterTarget,
-			environment:     map[string]string{branchEnvVarName: testBranchName},
+			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "0c57573cece531f840a167aa0ccc29b178b6de42",
-			expectedVersion: testDevVersion201,
+			expectedVersion: "2.0.1-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 8: untagged commit with multiple tagged parents",
 			inputHeadTarget: masterTarget,
-			environment:     map[string]string{branchEnvVarName: testBranchName},
+			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "c3726de44a2bb1bd898fdbe5632a90841636fa82",
-			expectedVersion: testDevVersion201,
+			expectedVersion: "2.0.1-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 9: untagged branch with single tagged parent",
 			inputHeadTarget: masterTarget,
-			environment:     map[string]string{branchEnvVarName: testBranchName},
-			inputRef:        testOriginBranchOf200,
-			expectedVersion: testDevVersion201,
+			environment:     map[string]string{branchEnvVarName: "test-branch"},
+			inputRef:        "origin/branch-of-2.0.0",
+			expectedVersion: "2.0.1-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 10: untagged branch with multiple tagged parents",
 			inputHeadTarget: masterTarget,
-			environment:     map[string]string{branchEnvVarName: testBranchName},
+			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "origin/branch-of-1.0.0",
-			expectedVersion: testDevVersion201,
+			expectedVersion: "2.0.1-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 11: unknown reference",
@@ -363,9 +351,9 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 		{
 			name:            "case 12: resolving complex tree with multiple common parents and long history",
 			inputHeadTarget: masterTarget,
-			environment:     map[string]string{branchEnvVarName: testBranchName},
+			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "origin/complex-tree",
-			expectedVersion: testDevVersion001,
+			expectedVersion: "0.0.1-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 13: ...",
@@ -374,7 +362,7 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 				tagPrefixEnvVarName: "module-c",
 			},
 			inputRef:        "ab61bc963b844551ffaf080f84d217e483323210",
-			expectedVersion: testVersion200,
+			expectedVersion: "2.0.0",
 		},
 		{
 			name:            "case 14: ...",
@@ -382,7 +370,7 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			environment: map[string]string{
 				tagPrefixEnvVarName: "module-a",
 			},
-			inputRef:        testCommitSHA4707,
+			inputRef:        "4707825fd7775c69fbd2f72a990e315b367b5409",
 			expectedVersion: "0.1.1",
 		},
 		{
@@ -391,7 +379,7 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			environment: map[string]string{
 				tagPrefixEnvVarName: "module-c",
 			},
-			inputRef:        testCommitSHA4707,
+			inputRef:        "4707825fd7775c69fbd2f72a990e315b367b5409",
 			expectedVersion: "1.1.0",
 		},
 		{
@@ -399,9 +387,9 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			inputHeadTarget: monorepoTarget,
 			environment: map[string]string{
 				tagPrefixEnvVarName: "module-b",
-				branchEnvVarName:    testBranchName,
+				branchEnvVarName:    "test-branch",
 			},
-			inputRef:        testCommitSHA4707,
+			inputRef:        "4707825fd7775c69fbd2f72a990e315b367b5409",
 			expectedVersion: "0.2.1-dev.test-branch.20260127.094959",
 		},
 		{
@@ -409,17 +397,17 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			inputHeadTarget: monorepoTarget,
 			environment: map[string]string{
 				tagPrefixEnvVarName: "module-not-exist",
-				branchEnvVarName:    testBranchName,
+				branchEnvVarName:    "test-branch",
 			},
 			inputRef:        "57aae3db71bcd176dd5a39eb8b487aae54930dcd",
-			expectedVersion: testDevVersion001,
+			expectedVersion: "0.0.1-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 18: ...",
 			inputHeadTarget: monorepoTarget,
-			environment:     map[string]string{branchEnvVarName: testBranchName},
+			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "ab61bc963b844551ffaf080f84d217e483323210",
-			expectedVersion: testDevVersion201,
+			expectedVersion: "2.0.1-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 19: ...",
@@ -427,9 +415,9 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			inputRef:        "35d336b84623963eb4a9ea554b4ebf3f93a5d63d",
 			environment: map[string]string{
 				tagPrefixEnvVarName: "module-a",
-				branchEnvVarName:    testBranchName,
+				branchEnvVarName:    "test-branch",
 			},
-			expectedVersion: testDevVersion001,
+			expectedVersion: "0.0.1-dev.test-branch.20260127.094959",
 		},
 	}
 
@@ -438,7 +426,7 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 
 	c := Config{
 		Dir: dir,
-		URL: testGitHubURL,
+		URL: "git@github.com:giantswarm/gitrepo-test.git",
 	}
 	repo, err := New(c)
 	if err != nil {
@@ -526,26 +514,26 @@ func Test_Repo_GetFileContent(t *testing.T) {
 	}{
 		{
 			name:     "case 0: get DCO file content",
-			path:     testFileDCO,
-			expected: testFileDCO,
+			path:     "DCO",
+			expected: "DCO",
 		},
 		{
 			name:     "case 1: get DCO file content on default branch (master)",
-			path:     testFileDCO,
-			expected: testFileDCO,
+			path:     "DCO",
+			expected: "DCO",
 			ref:      "master",
 		},
 		{
 			name:     "case 2: get DCO file content on branch-of-2.0.0 branch",
-			path:     testFileDCO,
-			expected: testFileDCO,
-			ref:      testOriginBranchOf200,
+			path:     "DCO",
+			expected: "DCO",
+			ref:      "origin/branch-of-2.0.0",
 		},
 		{
 			name:     "case 3: get DCO file content on v2.0.0 tag",
-			path:     testFileDCO,
-			expected: testFileDCO,
-			ref:      testTagV200,
+			path:     "DCO",
+			expected: "DCO",
+			ref:      "v2.0.0",
 		},
 		{
 			name:          "case 4: handle file not found error",
@@ -554,7 +542,7 @@ func Test_Repo_GetFileContent(t *testing.T) {
 		},
 		{
 			name:          "case 5: handle reference not found error",
-			path:          testFileDCO,
+			path:          "DCO",
 			ref:           "does-not-exist",
 			expectedError: &ReferenceNotFoundError{},
 		},
@@ -643,19 +631,19 @@ func Test_Repo_GetFolderContent(t *testing.T) {
 		{
 			name:     "case 0: get folder contents",
 			path:     ".",
-			expected: testFileDCO,
+			expected: "DCO",
 		},
 		{
 			name:     "case 1: get folder contents on a branch",
 			path:     ".",
-			expected: testFileDCO,
-			ref:      testOriginBranchOf200,
+			expected: "DCO",
+			ref:      "origin/branch-of-2.0.0",
 		},
 		{
 			name:     "case 2: get folder contents on a tag",
 			path:     ".",
-			expected: testFileDCO,
-			ref:      testTagV200,
+			expected: "DCO",
+			ref:      "v2.0.0",
 		},
 		{
 			name:          "case 3: folder not found error",
@@ -664,7 +652,7 @@ func Test_Repo_GetFolderContent(t *testing.T) {
 		},
 		{
 			name:          "case 4: handle reference not found error",
-			path:          testFileDCO,
+			path:          "DCO",
 			ref:           "does-not-exist",
 			expectedError: &ReferenceNotFoundError{},
 		},
@@ -675,7 +663,7 @@ func Test_Repo_GetFolderContent(t *testing.T) {
 
 	c := Config{
 		Dir: dir,
-		URL: testGitHubURL,
+		URL: "git@github.com:giantswarm/gitrepo-test.git",
 	}
 	repo, err := New(c)
 	if err != nil {
@@ -760,7 +748,7 @@ func Test_incrementPatch(t *testing.T) {
 	}{
 		{"1.2.3", "1.2.4", false},
 		{"0.0.0", "0.0.1", false},
-		{testVersion200, "2.0.1", false},
+		{"2.0.0", "2.0.1", false},
 		{"1.9.9", "1.9.10", false},
 		{"bad", "", true},
 		{"1.2", "", true},
@@ -797,8 +785,8 @@ func Test_currentBranch_unknownFallback(t *testing.T) {
 	t.Setenv(branchEnvVarName, "")
 	t.Chdir(t.TempDir())
 	got := currentBranch()
-	if got != unknownBranch {
-		t.Errorf("currentBranch() = %q, want %q (non-git dir should fall back)", got, unknownBranch)
+	if got != "unknown" {
+		t.Errorf("currentBranch() = %q, want %q (non-git dir should fall back)", got, "unknown")
 	}
 }
 
@@ -864,7 +852,7 @@ func newTestRepo(t *testing.T) (*Repo, *git.Repository) {
 // skipped when computing the dev build base version; only stable vX.Y.Z tags count.
 func Test_Repo_ResolveVersion_rcAncestor(t *testing.T) {
 	ctx := context.Background()
-	t.Setenv(branchEnvVarName, testBranchName)
+	t.Setenv(branchEnvVarName, "test-branch")
 	nowFunc = func() time.Time { return time.Date(2026, 1, 27, 9, 49, 59, 0, time.UTC) }
 	defer func() { nowFunc = time.Now }()
 
@@ -898,7 +886,7 @@ func Test_Repo_ResolveVersion_rcAncestor(t *testing.T) {
 // ref may be considered.
 func Test_Repo_ResolveVersion_nonReachableTagIgnored(t *testing.T) {
 	ctx := context.Background()
-	t.Setenv(branchEnvVarName, testBranchName)
+	t.Setenv(branchEnvVarName, "test-branch")
 	nowFunc = func() time.Time { return time.Date(2026, 1, 27, 9, 49, 59, 0, time.UTC) }
 	defer func() { nowFunc = time.Now }()
 
@@ -926,7 +914,7 @@ func Test_Repo_ResolveVersion_nonReachableTagIgnored(t *testing.T) {
 		t.Fatal(err)
 	}
 	sideHash := testCreateCommit(t, gitRepo, "side.txt", base.Add(time.Hour))
-	if _, err := gitRepo.CreateTag(testTagV200, sideHash, nil); err != nil {
+	if _, err := gitRepo.CreateTag("v2.0.0", sideHash, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/gitrepo/repo_test.go
+++ b/pkg/gitrepo/repo_test.go
@@ -14,13 +14,25 @@ import (
 
 	"github.com/go-errors/errors"
 
-	"github.com/go-git/go-git/v5"
+	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/google/go-cmp/cmp"
 )
 
 var update = flag.Bool("update", false, "update .golden files")
+
+const (
+	testGitHubURL         = "git@github.com:giantswarm/gitrepo-test.git"
+	testTagV200           = "v2.0.0"
+	testVersion200        = "2.0.0"
+	testBranchName        = "test-branch"
+	testDevVersion001     = "0.0.1-dev.test-branch.20260127.094959"
+	testDevVersion201     = "2.0.1-dev.test-branch.20260127.094959"
+	testOriginBranchOf200 = "origin/branch-of-2.0.0"
+	testCommitSHA4707     = "4707825fd7775c69fbd2f72a990e315b367b5409"
+	testFileDCO           = "DCO"
+)
 
 // Test_New_optionalURL tests if proper URL from origin branch is taken from
 // existing repository if none is specified.
@@ -32,13 +44,13 @@ func Test_New_optionalURL(t *testing.T) {
 	dir := "/tmp/gitrepo-test-new-optionalurl"
 	defer func() { _ = os.RemoveAll(dir) }()
 
-	url := "git@github.com:giantswarm/gitrepo-test.git"
+	url := testGitHubURL
 
 	// Clone the repo first.
 	{
 		c := Config{
 			Dir: dir,
-			URL: "git@github.com:giantswarm/gitrepo-test.git",
+			URL: testGitHubURL,
 		}
 
 		repo, err := New(c)
@@ -125,7 +137,7 @@ func Test_Repo_Head(t *testing.T) {
 
 		c := Config{
 			Dir: dir,
-			URL: "git@github.com:giantswarm/gitrepo-test.git",
+			URL: testGitHubURL,
 		}
 		repo, err = New(c)
 		if err != nil {
@@ -278,8 +290,8 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 		{
 			name:            "case 1: another version tag",
 			inputHeadTarget: masterTarget,
-			inputRef:        "v2.0.0",
-			expectedVersion: "2.0.0",
+			inputRef:        testTagV200,
+			expectedVersion: testVersion200,
 		},
 		{
 			name:            "case 2: tagged commit",
@@ -291,56 +303,56 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			name:            "case 3: another tagged commit",
 			inputHeadTarget: masterTarget,
 			inputRef:        "22b04802cd5ee933de078344fa53a3e37b826913",
-			expectedVersion: "2.0.0",
+			expectedVersion: testVersion200,
 		},
 		{
 			name:            "case 4: untagged commit without tagged parent",
 			inputHeadTarget: masterTarget,
-			environment:     map[string]string{branchEnvVarName: "test-branch"},
+			environment:     map[string]string{branchEnvVarName: testBranchName},
 			inputRef:        "2091354c7b8659f1846a876fbe2032fd1390d569",
-			expectedVersion: "0.0.1-dev.test-branch.20260127.094959",
+			expectedVersion: testDevVersion001,
 		},
 		{
 			name:            "case 5: untagged commit without tagged parent with detached head",
 			inputHeadTarget: "2091354c7b8659f1846a876fbe2032fd1390d569",
-			environment:     map[string]string{branchEnvVarName: "test-branch"},
+			environment:     map[string]string{branchEnvVarName: testBranchName},
 			inputRef:        "HEAD",
-			expectedVersion: "0.0.1-dev.test-branch.20260127.094959",
+			expectedVersion: testDevVersion001,
 		},
 		{
 			name:            "case 6: untagged commit with single tagged parent",
 			inputHeadTarget: masterTarget,
-			environment:     map[string]string{branchEnvVarName: "test-branch"},
+			environment:     map[string]string{branchEnvVarName: testBranchName},
 			inputRef:        "5ff7013b7a5f43d39b8da62361cfbfd4d3bf9a50",
 			expectedVersion: "1.0.1-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 7: another untagged commit with single tagged parent",
 			inputHeadTarget: masterTarget,
-			environment:     map[string]string{branchEnvVarName: "test-branch"},
+			environment:     map[string]string{branchEnvVarName: testBranchName},
 			inputRef:        "0c57573cece531f840a167aa0ccc29b178b6de42",
-			expectedVersion: "2.0.1-dev.test-branch.20260127.094959",
+			expectedVersion: testDevVersion201,
 		},
 		{
 			name:            "case 8: untagged commit with multiple tagged parents",
 			inputHeadTarget: masterTarget,
-			environment:     map[string]string{branchEnvVarName: "test-branch"},
+			environment:     map[string]string{branchEnvVarName: testBranchName},
 			inputRef:        "c3726de44a2bb1bd898fdbe5632a90841636fa82",
-			expectedVersion: "2.0.1-dev.test-branch.20260127.094959",
+			expectedVersion: testDevVersion201,
 		},
 		{
 			name:            "case 9: untagged branch with single tagged parent",
 			inputHeadTarget: masterTarget,
-			environment:     map[string]string{branchEnvVarName: "test-branch"},
-			inputRef:        "origin/branch-of-2.0.0",
-			expectedVersion: "2.0.1-dev.test-branch.20260127.094959",
+			environment:     map[string]string{branchEnvVarName: testBranchName},
+			inputRef:        testOriginBranchOf200,
+			expectedVersion: testDevVersion201,
 		},
 		{
 			name:            "case 10: untagged branch with multiple tagged parents",
 			inputHeadTarget: masterTarget,
-			environment:     map[string]string{branchEnvVarName: "test-branch"},
+			environment:     map[string]string{branchEnvVarName: testBranchName},
 			inputRef:        "origin/branch-of-1.0.0",
-			expectedVersion: "2.0.1-dev.test-branch.20260127.094959",
+			expectedVersion: testDevVersion201,
 		},
 		{
 			name:            "case 11: unknown reference",
@@ -351,9 +363,9 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 		{
 			name:            "case 12: resolving complex tree with multiple common parents and long history",
 			inputHeadTarget: masterTarget,
-			environment:     map[string]string{branchEnvVarName: "test-branch"},
+			environment:     map[string]string{branchEnvVarName: testBranchName},
 			inputRef:        "origin/complex-tree",
-			expectedVersion: "0.0.1-dev.test-branch.20260127.094959",
+			expectedVersion: testDevVersion001,
 		},
 		{
 			name:            "case 13: ...",
@@ -362,7 +374,7 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 				tagPrefixEnvVarName: "module-c",
 			},
 			inputRef:        "ab61bc963b844551ffaf080f84d217e483323210",
-			expectedVersion: "2.0.0",
+			expectedVersion: testVersion200,
 		},
 		{
 			name:            "case 14: ...",
@@ -370,7 +382,7 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			environment: map[string]string{
 				tagPrefixEnvVarName: "module-a",
 			},
-			inputRef:        "4707825fd7775c69fbd2f72a990e315b367b5409",
+			inputRef:        testCommitSHA4707,
 			expectedVersion: "0.1.1",
 		},
 		{
@@ -379,7 +391,7 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			environment: map[string]string{
 				tagPrefixEnvVarName: "module-c",
 			},
-			inputRef:        "4707825fd7775c69fbd2f72a990e315b367b5409",
+			inputRef:        testCommitSHA4707,
 			expectedVersion: "1.1.0",
 		},
 		{
@@ -387,9 +399,9 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			inputHeadTarget: monorepoTarget,
 			environment: map[string]string{
 				tagPrefixEnvVarName: "module-b",
-				branchEnvVarName:    "test-branch",
+				branchEnvVarName:    testBranchName,
 			},
-			inputRef:        "4707825fd7775c69fbd2f72a990e315b367b5409",
+			inputRef:        testCommitSHA4707,
 			expectedVersion: "0.2.1-dev.test-branch.20260127.094959",
 		},
 		{
@@ -397,17 +409,17 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			inputHeadTarget: monorepoTarget,
 			environment: map[string]string{
 				tagPrefixEnvVarName: "module-not-exist",
-				branchEnvVarName:    "test-branch",
+				branchEnvVarName:    testBranchName,
 			},
 			inputRef:        "57aae3db71bcd176dd5a39eb8b487aae54930dcd",
-			expectedVersion: "0.0.1-dev.test-branch.20260127.094959",
+			expectedVersion: testDevVersion001,
 		},
 		{
 			name:            "case 18: ...",
 			inputHeadTarget: monorepoTarget,
-			environment:     map[string]string{branchEnvVarName: "test-branch"},
+			environment:     map[string]string{branchEnvVarName: testBranchName},
 			inputRef:        "ab61bc963b844551ffaf080f84d217e483323210",
-			expectedVersion: "2.0.1-dev.test-branch.20260127.094959",
+			expectedVersion: testDevVersion201,
 		},
 		{
 			name:            "case 19: ...",
@@ -415,9 +427,9 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			inputRef:        "35d336b84623963eb4a9ea554b4ebf3f93a5d63d",
 			environment: map[string]string{
 				tagPrefixEnvVarName: "module-a",
-				branchEnvVarName:    "test-branch",
+				branchEnvVarName:    testBranchName,
 			},
-			expectedVersion: "0.0.1-dev.test-branch.20260127.094959",
+			expectedVersion: testDevVersion001,
 		},
 	}
 
@@ -426,7 +438,7 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 
 	c := Config{
 		Dir: dir,
-		URL: "git@github.com:giantswarm/gitrepo-test.git",
+		URL: testGitHubURL,
 	}
 	repo, err := New(c)
 	if err != nil {
@@ -514,26 +526,26 @@ func Test_Repo_GetFileContent(t *testing.T) {
 	}{
 		{
 			name:     "case 0: get DCO file content",
-			path:     "DCO",
-			expected: "DCO",
+			path:     testFileDCO,
+			expected: testFileDCO,
 		},
 		{
 			name:     "case 1: get DCO file content on default branch (master)",
-			path:     "DCO",
-			expected: "DCO",
+			path:     testFileDCO,
+			expected: testFileDCO,
 			ref:      "master",
 		},
 		{
 			name:     "case 2: get DCO file content on branch-of-2.0.0 branch",
-			path:     "DCO",
-			expected: "DCO",
-			ref:      "origin/branch-of-2.0.0",
+			path:     testFileDCO,
+			expected: testFileDCO,
+			ref:      testOriginBranchOf200,
 		},
 		{
 			name:     "case 3: get DCO file content on v2.0.0 tag",
-			path:     "DCO",
-			expected: "DCO",
-			ref:      "v2.0.0",
+			path:     testFileDCO,
+			expected: testFileDCO,
+			ref:      testTagV200,
 		},
 		{
 			name:          "case 4: handle file not found error",
@@ -542,7 +554,7 @@ func Test_Repo_GetFileContent(t *testing.T) {
 		},
 		{
 			name:          "case 5: handle reference not found error",
-			path:          "DCO",
+			path:          testFileDCO,
 			ref:           "does-not-exist",
 			expectedError: &ReferenceNotFoundError{},
 		},
@@ -631,19 +643,19 @@ func Test_Repo_GetFolderContent(t *testing.T) {
 		{
 			name:     "case 0: get folder contents",
 			path:     ".",
-			expected: "DCO",
+			expected: testFileDCO,
 		},
 		{
 			name:     "case 1: get folder contents on a branch",
 			path:     ".",
-			expected: "DCO",
-			ref:      "origin/branch-of-2.0.0",
+			expected: testFileDCO,
+			ref:      testOriginBranchOf200,
 		},
 		{
 			name:     "case 2: get folder contents on a tag",
 			path:     ".",
-			expected: "DCO",
-			ref:      "v2.0.0",
+			expected: testFileDCO,
+			ref:      testTagV200,
 		},
 		{
 			name:          "case 3: folder not found error",
@@ -652,7 +664,7 @@ func Test_Repo_GetFolderContent(t *testing.T) {
 		},
 		{
 			name:          "case 4: handle reference not found error",
-			path:          "DCO",
+			path:          testFileDCO,
 			ref:           "does-not-exist",
 			expectedError: &ReferenceNotFoundError{},
 		},
@@ -663,7 +675,7 @@ func Test_Repo_GetFolderContent(t *testing.T) {
 
 	c := Config{
 		Dir: dir,
-		URL: "git@github.com:giantswarm/gitrepo-test.git",
+		URL: testGitHubURL,
 	}
 	repo, err := New(c)
 	if err != nil {
@@ -726,8 +738,8 @@ func Test_sanitizeBranchName(t *testing.T) {
 		{"feature_underscored", "feature-underscored"},
 		{"feat/sub/deep", "feat-sub-deep"},
 		{"already-clean-123", "already-clean-123"},
-		{"feat//double-slash", "feat-double-slash"},  // consecutive invalid chars → single hyphen
-		{"__leading", "-leading"},                     // leading invalid chars
+		{"feat//double-slash", "feat-double-slash"}, // consecutive invalid chars → single hyphen
+		{"__leading", "-leading"},                   // leading invalid chars
 	}
 
 	for _, tc := range cases {
@@ -748,7 +760,7 @@ func Test_incrementPatch(t *testing.T) {
 	}{
 		{"1.2.3", "1.2.4", false},
 		{"0.0.0", "0.0.1", false},
-		{"2.0.0", "2.0.1", false},
+		{testVersion200, "2.0.1", false},
 		{"1.9.9", "1.9.10", false},
 		{"bad", "", true},
 		{"1.2", "", true},
@@ -785,8 +797,8 @@ func Test_currentBranch_unknownFallback(t *testing.T) {
 	t.Setenv(branchEnvVarName, "")
 	t.Chdir(t.TempDir())
 	got := currentBranch()
-	if got != "unknown" {
-		t.Errorf("currentBranch() = %q, want %q (non-git dir should fall back)", got, "unknown")
+	if got != unknownBranch {
+		t.Errorf("currentBranch() = %q, want %q (non-git dir should fall back)", got, unknownBranch)
 	}
 }
 
@@ -852,7 +864,7 @@ func newTestRepo(t *testing.T) (*Repo, *git.Repository) {
 // skipped when computing the dev build base version; only stable vX.Y.Z tags count.
 func Test_Repo_ResolveVersion_rcAncestor(t *testing.T) {
 	ctx := context.Background()
-	t.Setenv(branchEnvVarName, "test-branch")
+	t.Setenv(branchEnvVarName, testBranchName)
 	nowFunc = func() time.Time { return time.Date(2026, 1, 27, 9, 49, 59, 0, time.UTC) }
 	defer func() { nowFunc = time.Now }()
 
@@ -886,7 +898,7 @@ func Test_Repo_ResolveVersion_rcAncestor(t *testing.T) {
 // ref may be considered.
 func Test_Repo_ResolveVersion_nonReachableTagIgnored(t *testing.T) {
 	ctx := context.Background()
-	t.Setenv(branchEnvVarName, "test-branch")
+	t.Setenv(branchEnvVarName, testBranchName)
 	nowFunc = func() time.Time { return time.Date(2026, 1, 27, 9, 49, 59, 0, time.UTC) }
 	defer func() { nowFunc = time.Now }()
 
@@ -914,7 +926,7 @@ func Test_Repo_ResolveVersion_nonReachableTagIgnored(t *testing.T) {
 		t.Fatal(err)
 	}
 	sideHash := testCreateCommit(t, gitRepo, "side.txt", base.Add(time.Hour))
-	if _, err := gitRepo.CreateTag("v2.0.0", sideHash, nil); err != nil {
+	if _, err := gitRepo.CreateTag(testTagV200, sideHash, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/gitrepo/repo_test.go
+++ b/pkg/gitrepo/repo_test.go
@@ -298,49 +298,49 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			inputHeadTarget: masterTarget,
 			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "2091354c7b8659f1846a876fbe2032fd1390d569",
-			expectedVersion: "0.0.0-dev.test-branch.20260127.094959",
+			expectedVersion: "0.0.0-dev.test-branch.2026-01-27.09-49-59",
 		},
 		{
 			name:            "case 5: untagged commit without tagged parent with detached head",
 			inputHeadTarget: "2091354c7b8659f1846a876fbe2032fd1390d569",
 			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "HEAD",
-			expectedVersion: "0.0.0-dev.test-branch.20260127.094959",
+			expectedVersion: "0.0.0-dev.test-branch.2026-01-27.09-49-59",
 		},
 		{
 			name:            "case 6: untagged commit with single tagged parent",
 			inputHeadTarget: masterTarget,
 			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "5ff7013b7a5f43d39b8da62361cfbfd4d3bf9a50",
-			expectedVersion: "1.0.1-dev.test-branch.20260127.094959",
+			expectedVersion: "1.0.1-dev.test-branch.2026-01-27.09-49-59",
 		},
 		{
 			name:            "case 7: another untagged commit with single tagged parent",
 			inputHeadTarget: masterTarget,
 			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "0c57573cece531f840a167aa0ccc29b178b6de42",
-			expectedVersion: "2.0.1-dev.test-branch.20260127.094959",
+			expectedVersion: "2.0.1-dev.test-branch.2026-01-27.09-49-59",
 		},
 		{
 			name:            "case 8: untagged commit with multiple tagged parents",
 			inputHeadTarget: masterTarget,
 			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "c3726de44a2bb1bd898fdbe5632a90841636fa82",
-			expectedVersion: "2.0.1-dev.test-branch.20260127.094959",
+			expectedVersion: "2.0.1-dev.test-branch.2026-01-27.09-49-59",
 		},
 		{
 			name:            "case 9: untagged branch with single tagged parent",
 			inputHeadTarget: masterTarget,
 			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "origin/branch-of-2.0.0",
-			expectedVersion: "2.0.1-dev.test-branch.20260127.094959",
+			expectedVersion: "2.0.1-dev.test-branch.2026-01-27.09-49-59",
 		},
 		{
 			name:            "case 10: untagged branch with multiple tagged parents",
 			inputHeadTarget: masterTarget,
 			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "origin/branch-of-1.0.0",
-			expectedVersion: "2.0.1-dev.test-branch.20260127.094959",
+			expectedVersion: "2.0.1-dev.test-branch.2026-01-27.09-49-59",
 		},
 		{
 			name:            "case 11: unknown reference",
@@ -353,7 +353,7 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			inputHeadTarget: masterTarget,
 			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "origin/complex-tree",
-			expectedVersion: "0.0.0-dev.test-branch.20260127.094959",
+			expectedVersion: "0.0.0-dev.test-branch.2026-01-27.09-49-59",
 		},
 		{
 			name:            "case 13: ...",
@@ -390,7 +390,7 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 				branchEnvVarName:    "test-branch",
 			},
 			inputRef:        "4707825fd7775c69fbd2f72a990e315b367b5409",
-			expectedVersion: "0.2.1-dev.test-branch.20260127.094959",
+			expectedVersion: "0.2.1-dev.test-branch.2026-01-27.09-49-59",
 		},
 		{
 			name:            "case 17: ...",
@@ -400,14 +400,14 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 				branchEnvVarName:    "test-branch",
 			},
 			inputRef:        "57aae3db71bcd176dd5a39eb8b487aae54930dcd",
-			expectedVersion: "0.0.0-dev.test-branch.20260127.094959",
+			expectedVersion: "0.0.0-dev.test-branch.2026-01-27.09-49-59",
 		},
 		{
 			name:            "case 18: ...",
 			inputHeadTarget: monorepoTarget,
 			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "ab61bc963b844551ffaf080f84d217e483323210",
-			expectedVersion: "2.0.1-dev.test-branch.20260127.094959",
+			expectedVersion: "2.0.1-dev.test-branch.2026-01-27.09-49-59",
 		},
 		{
 			name:            "case 19: ...",
@@ -417,7 +417,7 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 				tagPrefixEnvVarName: "module-a",
 				branchEnvVarName:    "test-branch",
 			},
-			expectedVersion: "0.0.0-dev.test-branch.20260127.094959",
+			expectedVersion: "0.0.0-dev.test-branch.2026-01-27.09-49-59",
 		},
 	}
 
@@ -874,7 +874,7 @@ func Test_Repo_ResolveVersion_rcAncestor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	const want = "1.0.1-dev.test-branch.20260127.094959"
+	const want = "1.0.1-dev.test-branch.2026-01-27.09-49-59"
 	if version != want {
 		t.Errorf("ResolveVersion = %q, want %q — RC ancestor must be skipped, base must come from v1.0.0", version, want)
 	}
@@ -931,7 +931,7 @@ func Test_Repo_ResolveVersion_nonReachableTagIgnored(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	const want = "1.0.1-dev.test-branch.20260127.094959"
+	const want = "1.0.1-dev.test-branch.2026-01-27.09-49-59"
 	if version != want {
 		t.Errorf("ResolveVersion = %q, want %q — non-reachable v2.0.0 on side branch must be ignored", version, want)
 	}

--- a/pkg/gitrepo/repo_test.go
+++ b/pkg/gitrepo/repo_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -257,6 +258,9 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 	const masterTarget = "ref: refs/heads/master"
 	const monorepoTarget = "ref: refs/heads/monorepo"
 
+	nowFunc = func() time.Time { return time.Date(2026, 1, 27, 9, 49, 59, 0, time.UTC) }
+	defer func() { nowFunc = time.Now }()
+
 	testCases := []struct {
 		name            string
 		inputHeadTarget string
@@ -292,44 +296,51 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 		{
 			name:            "case 4: untagged commit without tagged parent",
 			inputHeadTarget: masterTarget,
+			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "2091354c7b8659f1846a876fbe2032fd1390d569",
-			expectedVersion: "0.0.0-2091354c7b8659f1846a876fbe2032fd1390d569",
+			expectedVersion: "0.0.1-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 5: untagged commit without tagged parent with detached head",
 			inputHeadTarget: "2091354c7b8659f1846a876fbe2032fd1390d569",
+			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "HEAD",
-			expectedVersion: "0.0.0-2091354c7b8659f1846a876fbe2032fd1390d569",
+			expectedVersion: "0.0.1-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 6: untagged commit with single tagged parent",
 			inputHeadTarget: masterTarget,
+			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "5ff7013b7a5f43d39b8da62361cfbfd4d3bf9a50",
-			expectedVersion: "1.0.0-5ff7013b7a5f43d39b8da62361cfbfd4d3bf9a50",
+			expectedVersion: "1.0.1-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 7: another untagged commit with single tagged parent",
 			inputHeadTarget: masterTarget,
+			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "0c57573cece531f840a167aa0ccc29b178b6de42",
-			expectedVersion: "2.0.0-0c57573cece531f840a167aa0ccc29b178b6de42",
+			expectedVersion: "2.0.1-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 8: untagged commit with multiple tagged parents",
 			inputHeadTarget: masterTarget,
+			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "c3726de44a2bb1bd898fdbe5632a90841636fa82",
-			expectedVersion: "2.0.0-c3726de44a2bb1bd898fdbe5632a90841636fa82",
+			expectedVersion: "2.0.1-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 9: untagged branch with single tagged parent",
 			inputHeadTarget: masterTarget,
+			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "origin/branch-of-2.0.0",
-			expectedVersion: "2.0.0-3901da4b6b4cf68e3d11a10f60916107828fa9a7",
+			expectedVersion: "2.0.1-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 10: untagged branch with multiple tagged parents",
 			inputHeadTarget: masterTarget,
+			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "origin/branch-of-1.0.0",
-			expectedVersion: "2.0.0-c3726de44a2bb1bd898fdbe5632a90841636fa82",
+			expectedVersion: "2.0.1-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 11: unknown reference",
@@ -340,8 +351,9 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 		{
 			name:            "case 12: resolving complex tree with multiple common parents and long history",
 			inputHeadTarget: masterTarget,
+			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "origin/complex-tree",
-			expectedVersion: "0.0.0-a42e026e60b4c191ffb29430f439ad4b3aced71b",
+			expectedVersion: "0.0.1-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 13: ...",
@@ -375,24 +387,27 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			inputHeadTarget: monorepoTarget,
 			environment: map[string]string{
 				tagPrefixEnvVarName: "module-b",
+				branchEnvVarName:    "test-branch",
 			},
 			inputRef:        "4707825fd7775c69fbd2f72a990e315b367b5409",
-			expectedVersion: "0.2.0-4707825fd7775c69fbd2f72a990e315b367b5409",
+			expectedVersion: "0.2.1-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 17: ...",
 			inputHeadTarget: monorepoTarget,
 			environment: map[string]string{
 				tagPrefixEnvVarName: "module-not-exist",
+				branchEnvVarName:    "test-branch",
 			},
 			inputRef:        "57aae3db71bcd176dd5a39eb8b487aae54930dcd",
-			expectedVersion: "0.0.0-57aae3db71bcd176dd5a39eb8b487aae54930dcd",
+			expectedVersion: "0.0.1-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 18: ...",
 			inputHeadTarget: monorepoTarget,
+			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "ab61bc963b844551ffaf080f84d217e483323210",
-			expectedVersion: "2.0.0-ab61bc963b844551ffaf080f84d217e483323210",
+			expectedVersion: "2.0.1-dev.test-branch.20260127.094959",
 		},
 		{
 			name:            "case 19: ...",
@@ -400,8 +415,9 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			inputRef:        "35d336b84623963eb4a9ea554b4ebf3f93a5d63d",
 			environment: map[string]string{
 				tagPrefixEnvVarName: "module-a",
+				branchEnvVarName:    "test-branch",
 			},
-			expectedVersion: "0.0.0-35d336b84623963eb4a9ea554b4ebf3f93a5d63d",
+			expectedVersion: "0.0.1-dev.test-branch.20260127.094959",
 		},
 	}
 
@@ -695,4 +711,228 @@ func containsFile(files []os.FileInfo, fileName string) bool {
 	}
 
 	return false
+}
+
+func Test_sanitizeBranchName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"main", "main"},
+		{"my-feature", "my-feature"},
+		{"feature/my-thing", "feature-my-thing"},
+		{"feature_underscored", "feature-underscored"},
+		{"feat/sub/deep", "feat-sub-deep"},
+		{"already-clean-123", "already-clean-123"},
+		{"feat//double-slash", "feat-double-slash"},  // consecutive invalid chars → single hyphen
+		{"__leading", "-leading"},                     // leading invalid chars
+	}
+
+	for _, tc := range cases {
+		got := sanitizeBranchName(tc.input)
+		if got != tc.expected {
+			t.Errorf("sanitizeBranchName(%q) = %q, want %q", tc.input, got, tc.expected)
+		}
+	}
+}
+
+func Test_incrementPatch(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		{"1.2.3", "1.2.4", false},
+		{"0.0.0", "0.0.1", false},
+		{"2.0.0", "2.0.1", false},
+		{"1.9.9", "1.9.10", false},
+		{"bad", "", true},
+		{"1.2", "", true},
+		{"1.2.x", "", true},
+	}
+
+	for _, tc := range cases {
+		got, err := incrementPatch(tc.input)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("incrementPatch(%q): expected error, got %q", tc.input, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("incrementPatch(%q): unexpected error: %v", tc.input, err)
+			continue
+		}
+		if got != tc.expected {
+			t.Errorf("incrementPatch(%q) = %q, want %q", tc.input, got, tc.expected)
+		}
+	}
+}
+
+func Test_currentBranch_envOverride(t *testing.T) {
+	t.Setenv(branchEnvVarName, "my-override-branch")
+	got := currentBranch()
+	if got != "my-override-branch" {
+		t.Errorf("currentBranch() = %q, want %q", got, "my-override-branch")
+	}
+}
+
+func Test_currentBranch_unknownFallback(t *testing.T) {
+	t.Setenv(branchEnvVarName, "")
+	t.Chdir(t.TempDir())
+	got := currentBranch()
+	if got != "unknown" {
+		t.Errorf("currentBranch() = %q, want %q (non-git dir should fall back)", got, "unknown")
+	}
+}
+
+func Test_currentBranch_detachedHead(t *testing.T) {
+	dir := t.TempDir()
+	gitRepo, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hash := testCreateCommit(t, gitRepo, "init.txt", time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+	w, _ := gitRepo.Worktree()
+	if err := w.Checkout(&git.CheckoutOptions{Hash: hash}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(branchEnvVarName, "")
+	t.Chdir(dir)
+	got := currentBranch()
+	if got != "HEAD" {
+		t.Errorf("currentBranch() = %q, want %q (detached HEAD should return \"HEAD\")", got, "HEAD")
+	}
+}
+
+// testCreateCommit adds a single file and creates a commit in gitRepo.
+func testCreateCommit(t *testing.T, gitRepo *git.Repository, filename string, when time.Time) plumbing.Hash {
+	t.Helper()
+	w, err := gitRepo.Worktree()
+	if err != nil {
+		t.Fatalf("Worktree: %v", err)
+	}
+	f, err := w.Filesystem.Create(filename)
+	if err != nil {
+		t.Fatalf("Create %s: %v", filename, err)
+	}
+	_, _ = fmt.Fprint(f, filename)
+	_ = f.Close()
+	if _, err = w.Add(filename); err != nil {
+		t.Fatalf("Add %s: %v", filename, err)
+	}
+	sig := &object.Signature{Name: "test", Email: "t@t.com", When: when}
+	hash, err := w.Commit(filename, &git.CommitOptions{Author: sig, Committer: sig})
+	if err != nil {
+		t.Fatalf("Commit %s: %v", filename, err)
+	}
+	return hash
+}
+
+// newTestRepo creates a fresh on-disk git repo in t.TempDir and wraps it in a Repo.
+func newTestRepo(t *testing.T) (*Repo, *git.Repository) {
+	t.Helper()
+	dir := t.TempDir()
+	gitRepo, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+	repo, err := New(Config{Dir: dir, URL: "https://example.com/test.git"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return repo, gitRepo
+}
+
+// Test_Repo_ResolveVersion_rcAncestor verifies that RC tags in the ancestry are
+// skipped when computing the dev build base version; only stable vX.Y.Z tags count.
+func Test_Repo_ResolveVersion_rcAncestor(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv(branchEnvVarName, "test-branch")
+	nowFunc = func() time.Time { return time.Date(2026, 1, 27, 9, 49, 59, 0, time.UTC) }
+	defer func() { nowFunc = time.Now }()
+
+	repo, gitRepo := newTestRepo(t)
+
+	base := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	stableHash := testCreateCommit(t, gitRepo, "stable.txt", base)
+	if _, err := gitRepo.CreateTag("v1.0.0", stableHash, nil); err != nil {
+		t.Fatal(err)
+	}
+	rcHash := testCreateCommit(t, gitRepo, "rc.txt", base.Add(time.Hour))
+	if _, err := gitRepo.CreateTag("v1.1.0-rc.1", rcHash, nil); err != nil {
+		t.Fatal(err)
+	}
+	headHash := testCreateCommit(t, gitRepo, "dev.txt", base.Add(2*time.Hour))
+
+	version, err := repo.ResolveVersion(ctx, headHash.String())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	const want = "1.0.1-dev.test-branch.20260127.094959"
+	if version != want {
+		t.Errorf("ResolveVersion = %q, want %q — RC ancestor must be skipped, base must come from v1.0.0", version, want)
+	}
+}
+
+// Test_Repo_ResolveVersion_nonReachableTagIgnored verifies that a higher-version
+// stable tag present in the repo but on a non-ancestor branch is never used as
+// the dev build base. Only tags reachable (i.e. ancestor commits) from the given
+// ref may be considered.
+func Test_Repo_ResolveVersion_nonReachableTagIgnored(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv(branchEnvVarName, "test-branch")
+	nowFunc = func() time.Time { return time.Date(2026, 1, 27, 9, 49, 59, 0, time.UTC) }
+	defer func() { nowFunc = time.Now }()
+
+	repo, gitRepo := newTestRepo(t)
+
+	base := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Initial commit on the default (master) branch, tagged v1.0.0.
+	stableHash := testCreateCommit(t, gitRepo, "stable.txt", base)
+	if _, err := gitRepo.CreateTag("v1.0.0", stableHash, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a side branch from the initial commit and tag it v2.0.0.
+	// This commit will NOT be reachable from our eventual HEAD on master.
+	w, err := gitRepo.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Checkout(&git.CheckoutOptions{
+		Hash:   stableHash,
+		Branch: plumbing.NewBranchReferenceName("side"),
+		Create: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	sideHash := testCreateCommit(t, gitRepo, "side.txt", base.Add(time.Hour))
+	if _, err := gitRepo.CreateTag("v2.0.0", sideHash, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Return to master and create the HEAD commit (parent: stableHash).
+	if err := w.Checkout(&git.CheckoutOptions{
+		Branch: plumbing.NewBranchReferenceName("master"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	headHash := testCreateCommit(t, gitRepo, "head.txt", base.Add(2*time.Hour))
+
+	// headHash ancestry: stableHash (v1.0.0). sideHash (v2.0.0) is not reachable.
+	version, err := repo.ResolveVersion(ctx, headHash.String())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	const want = "1.0.1-dev.test-branch.20260127.094959"
+	if version != want {
+		t.Errorf("ResolveVersion = %q, want %q — non-reachable v2.0.0 on side branch must be ignored", version, want)
+	}
 }


### PR DESCRIPTION
This PR makes this lib generate tags for helm charts according to https://handbook.giantswarm.io/docs/rfcs/semver-based-automatic-upgrades/
(TL;DR: stable tags unchanged, added `-rc.X` and `-dev.BRANCH.DATE.TIME`)

It also adds `gitrepo-version` as a command line tool easy to use in any CI/CD processes.

This is a breaking change and it will need a major version bump.
As there are only 2 other projects using this lib (https://devportal.giantswarm.io/catalog/default/component/gitrepo/dependencies), I would also like to rename it to `gitrepo-version`, as the current name is completely unrelated to what it does.

Towards: https://github.com/giantswarm/giantswarm/issues/35122
