### PR TITLE
Validation api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+- feat: implement the tagging RFC
+  (https://github.com/giantswarm/rfc/tree/main/semver-based-automatic-upgrades)
+- feat: add tag validation API
 
 ## [0.3.5] - 2026-05-13
 
@@ -39,14 +43,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add support for git tag prefixes in version calculation logics. If the `GS_GIT_TAG_PREFIX` environment variable
-  is set to e.g. `mymodule-a` then tags like `mymodule-a/v1.2.3` will be looked for in the history instead of the
-  normal semantic versioning tags, when the env var is not set (default). New tags will be generated in the same
-  format and with the same logic tho. For the above example, a few commits ahead of that tag the new version in
-  a test build would be: `1.2.3-<GIT_HASH>`. When on the tag itself, it would be: `1.2.3`. When no tag found with
-  the given prefix, then it would be: `0.0.0-<GIT_HASH>`. This replicates the original behaviour, just the tag
-  looked up for reference changes in the behaviour. This enables creating sort of mono repositories where multiple
-  modules, libraries or smaller projects are stored in a single repo that needs to be versioned separately.
+- Add support for git tag prefixes in version calculation logics. If the `GS_GIT_TAG_PREFIX` environment
+  variable is set to e.g. `mymodule-a` then tags like `mymodule-a/v1.2.3` will be looked for in the history
+  instead of the normal semantic versioning tags, when the env var is not set (default). New tags will be
+  generated in the same format and with the same logic tho. For the above example, a few commits ahead of that
+  tag the new version in a test build would be: `1.2.3-<GIT_HASH>`. When on the tag itself, it would be:
+  `1.2.3`. When no tag found with the given prefix, then it would be: `0.0.0-<GIT_HASH>`. This replicates the
+  original behaviour, just the tag looked up for reference changes in the behaviour. This enables creating
+  sort of mono repositories where multiple modules, libraries or smaller projects are stored in a single repo
+  that needs to be versioned separately.
 
 ## [0.2.4] - 2024-06-03
 
@@ -58,9 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Upgrade go-git and go-billy dependencies to their new location.
-  Moving from github.com/src-d to github.com/go-git.
-  v4 to v5 is a drop-in replacement, see https://github.com/go-git/go-git/releases/tag/v5.0.0
+- Upgrade go-git and go-billy dependencies to their new location. Moving from github.com/src-d to
+  github.com/go-git. v4 to v5 is a drop-in replacement, see
+  https://github.com/go-git/go-git/releases/tag/v5.0.0
 
 ## [0.2.2] - 2021-04-16
 

--- a/main.go
+++ b/main.go
@@ -1,13 +1,24 @@
-// gitrepo-version prints the semVer-compatible version for a git ref.
+// gitrepo-version prints or validates semVer-compatible version strings for git refs.
 //
-// For a ref that carries a stable tag (vX.Y.Z) it prints X.Y.Z.
-// For a pre-release tag (vX.Y.Z-rc.N) it prints X.Y.Z-rc.N.
-// For an untagged ref it prints a dev build:
+// Usage:
 //
-//	X.Y.(Z+1)-dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS>
+//	gitrepo-version [flags]
+//	gitrepo-version validate [--type dev|rc|stable|any] <version>
 //
-// where X.Y.Z is the most recent stable ancestor tag reachable from the ref,
-// or 0.0.0 when none exists.
+// Without a subcommand it resolves and prints the version for a git ref:
+//
+//	For a ref that carries a stable tag (vX.Y.Z) it prints X.Y.Z.
+//	For a pre-release tag (vX.Y.Z-rc.N) it prints X.Y.Z-rc.N.
+//	For an untagged ref it prints a dev build:
+//
+//	    X.Y.(Z+1)-dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS>
+//
+//	where X.Y.Z is the most recent stable ancestor tag reachable from the ref,
+//	or 0.0.0 when none exists.
+//
+// The "validate" subcommand checks whether a version string matches the
+// expected format.  It exits 0 and prints "valid" on success, exits 1 and
+// prints "invalid" otherwise.
 //
 // Environment variables:
 //
@@ -28,17 +39,28 @@ import (
 )
 
 func main() {
+	if len(os.Args) >= 2 && os.Args[1] == "validate" {
+		if err := runValidate(os.Args[2:]); err != nil {
+			if errors.Is(err, flag.ErrHelp) {
+				os.Exit(0)
+			}
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(2)
+		}
+		return
+	}
+
 	dir := flag.String("dir", ".", "path inside the git repository (resolved to the repo root)")
 	ref := flag.String("ref", "HEAD", "git ref to resolve: branch name, tag, or commit SHA")
 	flag.Parse()
 
-	if err := run(*dir, *ref); err != nil {
+	if err := runResolve(*dir, *ref); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func run(dir, ref string) error {
+func runResolve(dir, ref string) error {
 	ctx := context.Background()
 
 	topLevel, err := gitrepo.TopLevel(ctx, dir)
@@ -65,5 +87,41 @@ func run(dir, ref string) error {
 	}
 
 	fmt.Println(version)
+	return nil
+}
+
+func runValidate(args []string) error {
+	fs := flag.NewFlagSet("validate", flag.ContinueOnError)
+	typFlag := fs.String("type", "any", "version type to validate: dev, rc, stable, or any")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if fs.NArg() != 1 {
+		return fmt.Errorf("validate requires exactly one version argument\nusage: gitrepo-version validate [--type dev|rc|stable|any] <version>")
+	}
+	version := fs.Arg(0)
+
+	var ok bool
+	switch *typFlag {
+	case "stable":
+		ok = gitrepo.IsValidStable(version)
+	case "rc":
+		ok = gitrepo.IsValidRC(version)
+	case "dev":
+		ok = gitrepo.IsValidDev(version)
+	case "any":
+		ok = gitrepo.IsValid(version)
+	default:
+		return fmt.Errorf("unknown --type %q: must be dev, rc, stable, or any", *typFlag)
+	}
+
+	if ok {
+		fmt.Println("valid")
+	} else {
+		fmt.Println("invalid")
+		os.Exit(1)
+	}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -38,14 +38,38 @@ import (
 	"github.com/giantswarm/gitrepo/pkg/gitrepo"
 )
 
+// errInvalidVersion is returned by runValidate when the version string does
+// not match the requested format.  It is not a usage error — the caller
+// should print "invalid" and exit 1.
+var errInvalidVersion = errors.New("invalid")
+
 func main() {
+	flag.Usage = func() {
+		_, _ = fmt.Fprintf(flag.CommandLine.Output(), `Usage:
+  gitrepo-version [flags]
+  gitrepo-version validate [--type dev|rc|stable|any] <version>
+
+Subcommands:
+  validate    Check whether a version string matches a known format.
+              Exits 0 and prints "valid" on success, 1 and "invalid" otherwise.
+
+Flags:
+`)
+		flag.PrintDefaults()
+	}
+
 	if len(os.Args) >= 2 && os.Args[1] == "validate" {
 		if err := runValidate(os.Args[2:]); err != nil {
-			if errors.Is(err, flag.ErrHelp) {
+			switch {
+			case errors.Is(err, flag.ErrHelp):
 				os.Exit(0)
+			case errors.Is(err, errInvalidVersion):
+				fmt.Println("invalid")
+				os.Exit(1)
+			default:
+				fmt.Fprintf(os.Stderr, "error: %v\n", err)
+				os.Exit(2)
 			}
-			fmt.Fprintf(os.Stderr, "error: %v\n", err)
-			os.Exit(2)
 		}
 		return
 	}
@@ -119,9 +143,7 @@ func runValidate(args []string) error {
 
 	if ok {
 		fmt.Println("valid")
-	} else {
-		fmt.Println("invalid")
-		os.Exit(1)
+		return nil
 	}
-	return nil
+	return errInvalidVersion
 }

--- a/pkg/gitrepo/validate.go
+++ b/pkg/gitrepo/validate.go
@@ -1,0 +1,31 @@
+package gitrepo
+
+import "regexp"
+
+var validStableRegex = regexp.MustCompile(`^v?[0-9]+\.[0-9]+\.[0-9]+$`)
+var validRCRegex = regexp.MustCompile(`^v?[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$`)
+var validDevRegex = regexp.MustCompile(`^v?[0-9]+\.[0-9]+\.[0-9]+-dev\.[a-zA-Z0-9-]+\.[0-9]{4}-[0-9]{2}-[0-9]{2}\.[0-9]{2}-[0-9]{2}-[0-9]{2}$`)
+
+// IsValidStable reports whether version is a valid stable release version
+// (X.Y.Z or vX.Y.Z).
+func IsValidStable(version string) bool {
+	return validStableRegex.MatchString(version)
+}
+
+// IsValidRC reports whether version is a valid release-candidate version
+// (X.Y.Z-rc.N or vX.Y.Z-rc.N).
+func IsValidRC(version string) bool {
+	return validRCRegex.MatchString(version)
+}
+
+// IsValidDev reports whether version is a valid dev-build version
+// (X.Y.Z-dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS> or with a leading v).
+func IsValidDev(version string) bool {
+	return validDevRegex.MatchString(version)
+}
+
+// IsValid reports whether version is a valid version string in any of the
+// three recognised formats: stable, RC, or dev build.
+func IsValid(version string) bool {
+	return IsValidStable(version) || IsValidRC(version) || IsValidDev(version)
+}

--- a/pkg/gitrepo/validate.go
+++ b/pkg/gitrepo/validate.go
@@ -2,24 +2,33 @@ package gitrepo
 
 import "regexp"
 
-var validStableRegex = regexp.MustCompile(`^v?[0-9]+\.[0-9]+\.[0-9]+$`)
-var validRCRegex = regexp.MustCompile(`^v?[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$`)
-var validDevRegex = regexp.MustCompile(`^v?[0-9]+\.[0-9]+\.[0-9]+-dev\.[a-zA-Z0-9-]+\.[0-9]{4}-[0-9]{2}-[0-9]{2}\.[0-9]{2}-[0-9]{2}-[0-9]{2}$`)
+// numID is a semver-compliant numeric identifier: zero, or a positive integer
+// with no leading zeros (semver spec Rule 9).
+const numID = `(?:0|[1-9][0-9]*)`
+
+// vXYZ matches the optional "v" prefix and three dot-separated numeric
+// identifiers, each without leading zeros.
+const vXYZ = `v?` + numID + `\.` + numID + `\.` + numID
+
+var validStableRegex = regexp.MustCompile(`^` + vXYZ + `$`)
+var validRCRegex = regexp.MustCompile(`^` + vXYZ + `-rc\.` + numID + `$`)
+var validDevRegex = regexp.MustCompile(`^` + vXYZ + `-dev\.[a-zA-Z0-9-]+\.[0-9]{4}-[0-9]{2}-[0-9]{2}\.[0-9]{2}-[0-9]{2}-[0-9]{2}$`)
 
 // IsValidStable reports whether version is a valid stable release version
-// (X.Y.Z or vX.Y.Z).
+// (X.Y.Z or vX.Y.Z, no leading zeros in any component).
 func IsValidStable(version string) bool {
 	return validStableRegex.MatchString(version)
 }
 
 // IsValidRC reports whether version is a valid release-candidate version
-// (X.Y.Z-rc.N or vX.Y.Z-rc.N).
+// (X.Y.Z-rc.N or vX.Y.Z-rc.N, no leading zeros in any numeric component).
 func IsValidRC(version string) bool {
 	return validRCRegex.MatchString(version)
 }
 
 // IsValidDev reports whether version is a valid dev-build version
-// (X.Y.Z-dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS> or with a leading v).
+// (X.Y.Z-dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS> or with a leading v,
+// no leading zeros in X.Y.Z components).
 func IsValidDev(version string) bool {
 	return validDevRegex.MatchString(version)
 }

--- a/pkg/gitrepo/validate_test.go
+++ b/pkg/gitrepo/validate_test.go
@@ -25,6 +25,10 @@ func TestIsValidStable(t *testing.T) {
 		"abc",
 		"v",
 		"1.2.x",
+		// leading zeros in version components
+		"01.2.3",
+		"1.02.3",
+		"1.2.03",
 	}
 
 	for _, v := range valid {
@@ -60,6 +64,12 @@ func TestIsValidRC(t *testing.T) {
 		"1.2.3-rc.1.extra",
 		"1.2.3-dev.main.2026-01-27.09-49-59",
 		"abc",
+		// leading zeros
+		"01.2.3-rc.1",
+		"1.02.3-rc.1",
+		"1.2.03-rc.1",
+		"1.2.3-rc.01",
+		"1.2.3-rc.00",
 	}
 
 	for _, v := range valid {
@@ -109,6 +119,10 @@ func TestIsValidDev(t *testing.T) {
 		"1.2.3-dev.main.2026-01-27.09-49-59.extra",
 		// no v prefix required but "vv" is wrong
 		"vv1.2.3-dev.main.2026-01-27.09-49-59",
+		// leading zeros in version components
+		"01.2.3-dev.main.2026-01-27.09-49-59",
+		"1.02.3-dev.main.2026-01-27.09-49-59",
+		"1.2.03-dev.main.2026-01-27.09-49-59",
 	}
 
 	for _, v := range valid {

--- a/pkg/gitrepo/validate_test.go
+++ b/pkg/gitrepo/validate_test.go
@@ -1,0 +1,160 @@
+package gitrepo
+
+import "testing"
+
+func TestIsValidStable(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{
+		"1.2.3",
+		"0.0.0",
+		"10.20.30",
+		"v1.2.3",
+		"v0.0.0",
+		"v10.20.30",
+	}
+	invalid := []string{
+		"",
+		"1.2",
+		"1.2.3.4",
+		"1.2.3-rc.1",
+		"v1.2.3-rc.1",
+		"1.2.3-dev.main.2026-01-27.09-49-59",
+		"v1.2.3-dev.main.2026-01-27.09-49-59",
+		"1.2.3-anything",
+		"abc",
+		"v",
+		"1.2.x",
+	}
+
+	for _, v := range valid {
+		if !IsValidStable(v) {
+			t.Errorf("IsValidStable(%q) = false, want true", v)
+		}
+	}
+	for _, v := range invalid {
+		if IsValidStable(v) {
+			t.Errorf("IsValidStable(%q) = true, want false", v)
+		}
+	}
+}
+
+func TestIsValidRC(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{
+		"1.2.3-rc.1",
+		"1.2.3-rc.0",
+		"1.2.3-rc.42",
+		"v1.2.3-rc.1",
+		"v0.0.1-rc.99",
+	}
+	invalid := []string{
+		"",
+		"1.2.3",
+		"v1.2.3",
+		"1.2.3-rc",
+		"1.2.3-rc.",
+		"1.2.3-rc.a",
+		"1.2.3-RC.1",
+		"1.2.3-rc.1.extra",
+		"1.2.3-dev.main.2026-01-27.09-49-59",
+		"abc",
+	}
+
+	for _, v := range valid {
+		if !IsValidRC(v) {
+			t.Errorf("IsValidRC(%q) = false, want true", v)
+		}
+	}
+	for _, v := range invalid {
+		if IsValidRC(v) {
+			t.Errorf("IsValidRC(%q) = true, want false", v)
+		}
+	}
+}
+
+func TestIsValidDev(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{
+		"1.2.3-dev.main.2026-01-27.09-49-59",
+		"0.0.0-dev.main.2026-01-27.09-49-59",
+		"1.2.4-dev.my-feature.2026-01-27.09-49-59",
+		"v1.2.3-dev.main.2026-01-27.09-49-59",
+		"v0.0.0-dev.main.2026-01-27.09-49-59",
+		"2.0.1-dev.test-branch.2026-01-27.09-49-59",
+		// branch names with hyphens
+		"1.0.1-dev.feature-my-thing.2026-05-21.14-30-00",
+		// single-char branch
+		"1.0.0-dev.x.2026-05-21.00-00-00",
+	}
+	invalid := []string{
+		"",
+		"1.2.3",
+		"1.2.3-rc.1",
+		// missing time segment
+		"1.2.3-dev.main.2026-01-27",
+		// wrong date separator (slashes)
+		"1.2.3-dev.main.2026/01/27.09-49-59",
+		// wrong time separator (colons)
+		"1.2.3-dev.main.2026-01-27.09:49:59",
+		// date wrong length
+		"1.2.3-dev.main.26-01-27.09-49-59",
+		// branch with slash (not sanitized)
+		"1.2.3-dev.feat/foo.2026-01-27.09-49-59",
+		// empty branch
+		"1.2.3-dev..2026-01-27.09-49-59",
+		// extra trailing segment
+		"1.2.3-dev.main.2026-01-27.09-49-59.extra",
+		// no v prefix required but "vv" is wrong
+		"vv1.2.3-dev.main.2026-01-27.09-49-59",
+	}
+
+	for _, v := range valid {
+		if !IsValidDev(v) {
+			t.Errorf("IsValidDev(%q) = false, want true", v)
+		}
+	}
+	for _, v := range invalid {
+		if IsValidDev(v) {
+			t.Errorf("IsValidDev(%q) = true, want false", v)
+		}
+	}
+}
+
+func TestIsValid(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{
+		// stable
+		"1.2.3",
+		"v1.2.3",
+		// RC
+		"1.2.3-rc.1",
+		"v1.2.3-rc.1",
+		// dev
+		"1.2.4-dev.main.2026-01-27.09-49-59",
+		"v1.2.4-dev.main.2026-01-27.09-49-59",
+	}
+	invalid := []string{
+		"",
+		"abc",
+		"1.2",
+		"1.2.3.4",
+		"1.2.3-",
+		"1.2.3-rc",
+		"1.2.3-dev.main.2026-01-27",
+	}
+
+	for _, v := range valid {
+		if !IsValid(v) {
+			t.Errorf("IsValid(%q) = false, want true", v)
+		}
+	}
+	for _, v := range invalid {
+		if IsValid(v) {
+			t.Errorf("IsValid(%q) = true, want false", v)
+		}
+	}
+}


### PR DESCRIPTION
Add library methods and CLI calls to validate a tag against the standard checking if it is of type rc-dev-stable-any.

Towards: https://github.com/giantswarm/giantswarm/issues/35122