### PR TITLE
fix: use commiter's timestamp 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Dev build versions now derive their timestamp from the committer date of the resolved commit (in UTC)
+  instead of the current wall-clock time. This makes the version deterministic: resolving the same commit
+  always yields the same `X.Y.Z-dev.<branch>.<date>.<time>` string.
+
 ## [1.1.2] - 2026-05-28
 
 ### Fixed

--- a/pkg/gitsemver/repo.go
+++ b/pkg/gitsemver/repo.go
@@ -11,7 +11,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	billy "github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/osfs"
@@ -38,9 +37,6 @@ var branchEnvVarName = "GS_BRANCH_NAME"
 // branchSanitizeRegex replaces one or more consecutive invalid semVer
 // pre-release characters with a single hyphen.
 var branchSanitizeRegex = regexp.MustCompile(`[^a-zA-Z0-9-]+`)
-
-// nowFunc is the clock used for dev build timestamps; overridable in tests.
-var nowFunc = time.Now
 
 const unknownBranch = "unknown"
 
@@ -324,9 +320,11 @@ func buildVersionMaps(tagsByHash map[string][]string, tagPrefix string) (version
 //   - Untagged commit → returns a semVer dev build:
 //     "X.Y.(Z+1)-dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS>"
 //     where X.Y.Z is the most recent stable (non-pre-release) ancestor tag reachable
-//     from the reference, or "0.0.0" when no stable ancestor exists. The branch name
-//     is resolved from GS_BRANCH_NAME env var, then the HEAD branch of the CWD git
-//     repo, then "unknown". Non-reachable tags are never used as the base.
+//     from the reference, or "0.0.0" when no stable ancestor exists. The timestamp is
+//     the committer date (in UTC) of the resolved commit, so the version is stable for
+//     a given commit. The branch name is resolved from GS_BRANCH_NAME env var, then the
+//     HEAD branch of the CWD git repo, then "unknown". Non-reachable tags are never used
+//     as the base.
 //
 // If GS_GIT_TAG_PREFIX is set, only tags prefixed with "<value>/" are considered,
 // e.g. "module-a/v1.2.3". The prefix, separator, and "v" are stripped from the result.
@@ -427,7 +425,7 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 		}
 	}
 	branch := sanitizeBranchName(currentBranch())
-	t := nowFunc().UTC()
+	t := commit.Committer.When.UTC()
 	pseudoVersion := fmt.Sprintf("%s-dev.%s.%s.%s",
 		base,
 		branch,

--- a/pkg/gitsemver/repo_test.go
+++ b/pkg/gitsemver/repo_test.go
@@ -251,9 +251,6 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 	const masterTarget = "ref: refs/heads/master"
 	const monorepoTarget = "ref: refs/heads/monorepo"
 
-	nowFunc = func() time.Time { return time.Date(2026, 1, 27, 9, 49, 59, 0, time.UTC) }
-	defer func() { nowFunc = time.Now }()
-
 	testCases := []struct {
 		name            string
 		inputHeadTarget string
@@ -291,49 +288,49 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			inputHeadTarget: masterTarget,
 			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "2091354c7b8659f1846a876fbe2032fd1390d569",
-			expectedVersion: "0.0.0-dev.test-branch.2026-01-27.09-49-59",
+			expectedVersion: "0.0.0-dev.test-branch.2019-11-08.11-42-00",
 		},
 		{
 			name:            "case 5: untagged commit without tagged parent with detached head",
 			inputHeadTarget: "2091354c7b8659f1846a876fbe2032fd1390d569",
 			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "HEAD",
-			expectedVersion: "0.0.0-dev.test-branch.2026-01-27.09-49-59",
+			expectedVersion: "0.0.0-dev.test-branch.2019-11-08.11-42-00",
 		},
 		{
 			name:            "case 6: untagged commit with single tagged parent",
 			inputHeadTarget: masterTarget,
 			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "5ff7013b7a5f43d39b8da62361cfbfd4d3bf9a50",
-			expectedVersion: "1.0.1-dev.test-branch.2026-01-27.09-49-59",
+			expectedVersion: "1.0.1-dev.test-branch.2019-11-08.11-45-03",
 		},
 		{
 			name:            "case 7: another untagged commit with single tagged parent",
 			inputHeadTarget: masterTarget,
 			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "0c57573cece531f840a167aa0ccc29b178b6de42",
-			expectedVersion: "2.0.1-dev.test-branch.2026-01-27.09-49-59",
+			expectedVersion: "2.0.1-dev.test-branch.2019-11-08.11-45-05",
 		},
 		{
 			name:            "case 8: untagged commit with multiple tagged parents",
 			inputHeadTarget: masterTarget,
 			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "c3726de44a2bb1bd898fdbe5632a90841636fa82",
-			expectedVersion: "2.0.1-dev.test-branch.2026-01-27.09-49-59",
+			expectedVersion: "2.0.1-dev.test-branch.2019-11-08.11-45-06",
 		},
 		{
 			name:            "case 9: untagged branch with single tagged parent",
 			inputHeadTarget: masterTarget,
 			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "origin/branch-of-2.0.0",
-			expectedVersion: "2.0.1-dev.test-branch.2026-01-27.09-49-59",
+			expectedVersion: "2.0.1-dev.test-branch.2019-11-08.11-45-06",
 		},
 		{
 			name:            "case 10: untagged branch with multiple tagged parents",
 			inputHeadTarget: masterTarget,
 			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "origin/branch-of-1.0.0",
-			expectedVersion: "2.0.1-dev.test-branch.2026-01-27.09-49-59",
+			expectedVersion: "2.0.1-dev.test-branch.2019-11-08.11-45-06",
 		},
 		{
 			name:            "case 11: unknown reference",
@@ -346,7 +343,7 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 			inputHeadTarget: masterTarget,
 			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "origin/complex-tree",
-			expectedVersion: "0.0.0-dev.test-branch.2026-01-27.09-49-59",
+			expectedVersion: "0.0.0-dev.test-branch.2019-11-18.12-08-09",
 		},
 		{
 			name:            "case 13: ...",
@@ -383,7 +380,7 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 				branchEnvVarName:    "test-branch",
 			},
 			inputRef:        "4707825fd7775c69fbd2f72a990e315b367b5409",
-			expectedVersion: "0.2.1-dev.test-branch.2026-01-27.09-49-59",
+			expectedVersion: "0.2.1-dev.test-branch.2024-07-25.13-13-06",
 		},
 		{
 			name:            "case 17: ...",
@@ -393,14 +390,14 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 				branchEnvVarName:    "test-branch",
 			},
 			inputRef:        "57aae3db71bcd176dd5a39eb8b487aae54930dcd",
-			expectedVersion: "0.0.0-dev.test-branch.2026-01-27.09-49-59",
+			expectedVersion: "0.0.0-dev.test-branch.2024-07-25.13-14-06",
 		},
 		{
 			name:            "case 18: ...",
 			inputHeadTarget: monorepoTarget,
 			environment:     map[string]string{branchEnvVarName: "test-branch"},
 			inputRef:        "ab61bc963b844551ffaf080f84d217e483323210",
-			expectedVersion: "2.0.1-dev.test-branch.2026-01-27.09-49-59",
+			expectedVersion: "2.0.1-dev.test-branch.2024-07-25.13-13-25",
 		},
 		{
 			name:            "case 19: ...",
@@ -410,7 +407,7 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 				tagPrefixEnvVarName: "module-a",
 				branchEnvVarName:    "test-branch",
 			},
-			expectedVersion: "0.0.0-dev.test-branch.2026-01-27.09-49-59",
+			expectedVersion: "0.0.0-dev.test-branch.2020-04-24.08-41-47",
 		},
 	}
 
@@ -844,8 +841,6 @@ func newTestRepo(t *testing.T) (*Repo, *git.Repository) {
 func Test_Repo_ResolveVersion_rcAncestor(t *testing.T) {
 	ctx := context.Background()
 	t.Setenv(branchEnvVarName, "test-branch")
-	nowFunc = func() time.Time { return time.Date(2026, 1, 27, 9, 49, 59, 0, time.UTC) }
-	defer func() { nowFunc = time.Now }()
 
 	repo, gitRepo := newTestRepo(t)
 
@@ -865,7 +860,8 @@ func Test_Repo_ResolveVersion_rcAncestor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	const want = "1.0.1-dev.test-branch.2026-01-27.09-49-59"
+	// Timestamp is the committer date of the HEAD commit (base + 2h).
+	const want = "1.0.1-dev.test-branch.2020-01-01.02-00-00"
 	if version != want {
 		t.Errorf("ResolveVersion = %q, want %q — RC ancestor must be skipped, base must come from v1.0.0", version, want)
 	}
@@ -878,8 +874,6 @@ func Test_Repo_ResolveVersion_rcAncestor(t *testing.T) {
 func Test_Repo_ResolveVersion_nonReachableTagIgnored(t *testing.T) {
 	ctx := context.Background()
 	t.Setenv(branchEnvVarName, "test-branch")
-	nowFunc = func() time.Time { return time.Date(2026, 1, 27, 9, 49, 59, 0, time.UTC) }
-	defer func() { nowFunc = time.Now }()
 
 	repo, gitRepo := newTestRepo(t)
 
@@ -922,7 +916,8 @@ func Test_Repo_ResolveVersion_nonReachableTagIgnored(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	const want = "1.0.1-dev.test-branch.2026-01-27.09-49-59"
+	// Timestamp is the committer date of the HEAD commit (base + 2h).
+	const want = "1.0.1-dev.test-branch.2020-01-01.02-00-00"
 	if version != want {
 		t.Errorf("ResolveVersion = %q, want %q — non-reachable v2.0.0 on side branch must be ignored", version, want)
 	}


### PR DESCRIPTION
use commiter's timestamp of the analysed commit instead of the wall clock