### PR TITLE
fix: pick highest semver tag when a commit has multiple version tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - When a single commit reachable from HEAD carries multiple version tags, `get` and `next` no longer fail.
   The highest tag in semver terms is chosen and a warning listing all discovered tags and the chosen one is
   printed to stderr.
-  
+
 ### Changed
 
 - Release binaries now include darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64 alongside the existing linux targets. Windows binaries are named `gitsemver-windows-<arch>.exe`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- When a single commit reachable from HEAD carries multiple version tags, `get` and `next` no longer fail.
+  The highest tag in semver terms is chosen and a warning listing all discovered tags and the chosen one is
+  printed to stderr.
+
 ## [2.0.0] - 2026-06-02
 
 ### Changed

--- a/pkg/gitsemver/next_repo_test.go
+++ b/pkg/gitsemver/next_repo_test.go
@@ -1,6 +1,7 @@
 package gitsemver
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"strings"
@@ -337,29 +338,37 @@ func Test_Repo_NextVersion_monorepoPrefixFiltering(t *testing.T) {
 	}
 }
 
-// A commit carrying two version tags must produce an error, not silently
-// return a randomly chosen version (regression test for the dead versionTags
-// guard that was scoped inside the inner per-tag loop).
-func Test_Repo_NextVersion_multipleTagsOnSameCommit_errors(t *testing.T) {
+// A commit carrying multiple version tags must not error: NextVersion computes
+// the bump from the highest-semver tag and emits a warning listing every
+// discovered tag.
+func Test_Repo_NextVersion_multipleTagsOnSameCommit_picksHighest(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	repo, gitRepo := newTestRepo(t)
+	var warn bytes.Buffer
+	repo.warn = &warn
 
 	h := testCreateCommit(t, gitRepo, "a.txt", nextTestBaseTime)
-	if _, err := gitRepo.CreateTag("v1.0.0", h, nil); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := gitRepo.CreateTag("v1.0.1", h, nil); err != nil {
-		t.Fatal(err)
+	// Created lowest-last to prove selection is by semver, not creation order.
+	for _, tag := range []string{"v1.0.1", "v1.0.0"} {
+		if _, err := gitRepo.CreateTag(tag, h, nil); err != nil {
+			t.Fatal(err)
+		}
 	}
 
-	_, err := repo.NextVersion(ctx, "patch")
-	var execErr *ExecutionFailedError
-	if !errors.As(err, &execErr) {
-		t.Fatalf("err = %T (%v), want *ExecutionFailedError", err, err)
+	got, err := repo.NextVersion(ctx, "patch")
+	if err != nil {
+		t.Fatalf("NextVersion: unexpected error %v", err)
 	}
-	if !strings.Contains(execErr.Error(), "multiple version tags") {
-		t.Errorf("unexpected error message: %v", execErr)
+	if got != "1.0.2" {
+		t.Errorf("NextVersion = %q, want %q (patch bump from highest tag 1.0.1)", got, "1.0.2")
+	}
+
+	out := warn.String()
+	for _, want := range []string{"v1.0.0", "v1.0.1"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("warning %q does not list discovered tag %q", out, want)
+		}
 	}
 }
 

--- a/pkg/gitsemver/repo.go
+++ b/pkg/gitsemver/repo.go
@@ -78,6 +78,9 @@ type Config struct {
 	AuthBasicToken string
 	Dir            string
 	URL            string
+	// WarnWriter is where non-fatal warnings are written. If nil, os.Stderr is
+	// used. Set this to redirect or suppress warnings in library use.
+	WarnWriter io.Writer
 }
 
 type Repo struct {
@@ -135,13 +138,17 @@ func New(config Config) (*Repo, error) {
 		config.URL = remote.Config().URLs[0]
 	}
 
+	warnW := io.Writer(os.Stderr)
+	if config.WarnWriter != nil {
+		warnW = config.WarnWriter
+	}
 	r := &Repo{
 		url: config.URL,
 
 		auth:     auth,
 		storage:  storage,
 		worktree: worktree,
-		warn:     os.Stderr,
+		warn:     warnW,
 	}
 
 	return r, nil
@@ -328,7 +335,7 @@ func buildVersionMaps(warn io.Writer, tagsByHash map[string][]string, tagPrefix 
 				return nil, nil, err
 			}
 			if len(versionTags) > 1 {
-				_, _ = fmt.Fprintf(warn, "warning: commit %s carries multiple version tags %v; using the highest, %q\n", hash, versionTags, chosen)
+				_, _ = fmt.Fprintf(warn, "warning: commit %s carries multiple version tags %s; using the highest, %q\n", hash, strings.Join(versionTags, ", "), chosen)
 			}
 			versionsByHash[hash] = versionOf(chosen)
 		}

--- a/pkg/gitsemver/repo.go
+++ b/pkg/gitsemver/repo.go
@@ -86,6 +86,11 @@ type Repo struct {
 	auth     transport.AuthMethod
 	storage  *filesystem.Storage
 	worktree billy.Filesystem
+
+	// warn is where non-fatal warnings (e.g. a commit carrying multiple
+	// version tags) are written. It defaults to os.Stderr so warnings never
+	// pollute the version printed to stdout; tests override it to capture output.
+	warn io.Writer
 }
 
 func New(config Config) (*Repo, error) {
@@ -136,6 +141,7 @@ func New(config Config) (*Repo, error) {
 		auth:     auth,
 		storage:  storage,
 		worktree: worktree,
+		warn:     os.Stderr,
 	}
 
 	return r, nil
@@ -278,39 +284,85 @@ func (r *Repo) HeadTag(ctx context.Context) (string, error) {
 // buildVersionMaps filters tagsByHash by tagPrefix and returns two maps keyed
 // by commit SHA: versionsByHash (all semver tags) and stableVersionsByHash
 // (stable-only tags). Version strings in both maps have no leading "v".
-// It returns an error if a single commit carries more than one version tag.
-func buildVersionMaps(tagsByHash map[string][]string, tagPrefix string) (versionsByHash, stableVersionsByHash map[string]string, err error) {
+//
+// When a single commit carries more than one version tag — which happens, for
+// example, when several tags point at the same commit — the highest tag in
+// semver terms is chosen and a warning listing every discovered tag and the
+// chosen one is written to warn.
+func buildVersionMaps(warn io.Writer, tagsByHash map[string][]string, tagPrefix string) (versionsByHash, stableVersionsByHash map[string]string, err error) {
 	versionsByHash = map[string]string{}
 	stableVersionsByHash = map[string]string{}
+
+	// versionOf strips the prefix and leading "v" so the remainder can be
+	// parsed and compared by compareSemver.
+	versionOf := func(t string) string { return strings.TrimPrefix(t, "v") }
+	if tagPrefix != "" {
+		versionOf = func(t string) string {
+			return strings.TrimPrefix(strings.TrimPrefix(t, tagPrefix+"/"), "v")
+		}
+	}
+
 	for hash, tags := range tagsByHash {
-		var versionTags []string
+		var versionTags, stableTags []string
 		for _, t := range tags {
 			if tagPrefix != "" {
 				if prefixedTagRegex.MatchString(t) && strings.HasPrefix(t, tagPrefix+"/") {
 					versionTags = append(versionTags, t)
-					version := strings.TrimPrefix(strings.TrimPrefix(t, tagPrefix+"/"), "v")
-					versionsByHash[hash] = version
-					tagWithoutPrefix := strings.TrimPrefix(t, tagPrefix+"/")
-					if stableTagRegex.MatchString(tagWithoutPrefix) {
-						stableVersionsByHash[hash] = version
+					if stableTagRegex.MatchString(strings.TrimPrefix(t, tagPrefix+"/")) {
+						stableTags = append(stableTags, t)
 					}
 				}
 			} else {
 				if tagRegex.MatchString(t) {
 					versionTags = append(versionTags, t)
-					version := strings.TrimPrefix(t, "v")
-					versionsByHash[hash] = version
 					if stableTagRegex.MatchString(t) {
-						stableVersionsByHash[hash] = version
+						stableTags = append(stableTags, t)
 					}
 				}
 			}
 		}
-		if len(versionTags) > 1 {
-			return nil, nil, &ExecutionFailedError{message: fmt.Sprintf("multiple version tags %#v found for hash %#q", versionTags, hash)}
+
+		if len(versionTags) > 0 {
+			chosen, err := highestVersionTag(versionTags, versionOf)
+			if err != nil {
+				return nil, nil, err
+			}
+			if len(versionTags) > 1 {
+				_, _ = fmt.Fprintf(warn, "warning: commit %s carries multiple version tags %v; using the highest, %q\n", hash, versionTags, chosen)
+			}
+			versionsByHash[hash] = versionOf(chosen)
+		}
+		if len(stableTags) > 0 {
+			chosen, err := highestVersionTag(stableTags, versionOf)
+			if err != nil {
+				return nil, nil, err
+			}
+			stableVersionsByHash[hash] = versionOf(chosen)
 		}
 	}
 	return versionsByHash, stableVersionsByHash, nil
+}
+
+// highestVersionTag returns the tag with the highest semver precedence among
+// tags, all of which are assumed to belong to the same commit. versionOf maps a
+// tag name to the bare version string that compareSemver understands (prefix
+// and leading "v" stripped). tags must be non-empty.
+func highestVersionTag(tags []string, versionOf func(string) string) (string, error) {
+	best := tags[0]
+	bestParsed, err := parseVersionString(versionOf(best))
+	if err != nil {
+		return "", err
+	}
+	for _, t := range tags[1:] {
+		parsed, err := parseVersionString(versionOf(t))
+		if err != nil {
+			return "", err
+		}
+		if compareSemver(parsed, bestParsed) > 0 {
+			best, bestParsed = t, parsed
+		}
+	}
+	return best, nil
 }
 
 // ResolveVersion resolves the version for a git reference:
@@ -343,7 +395,7 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	versionsByHash, stableVersionsByHash, err := buildVersionMaps(tagsByHash, tagPrefix)
+	versionsByHash, stableVersionsByHash, err := buildVersionMaps(r.warn, tagsByHash, tagPrefix)
 	if err != nil {
 		return "", err
 	}
@@ -460,7 +512,7 @@ func (r *Repo) NextVersion(ctx context.Context, bumpType string) (string, error)
 	if err != nil {
 		return "", err
 	}
-	versionsByHash, _, err := buildVersionMaps(tagsByHash, tagPrefix)
+	versionsByHash, _, err := buildVersionMaps(r.warn, tagsByHash, tagPrefix)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/gitsemver/repo_test.go
+++ b/pkg/gitsemver/repo_test.go
@@ -984,3 +984,31 @@ func Test_Repo_ResolveVersion_devBuild_multipleAncestorTags_picksHighest(t *test
 		t.Errorf("ResolveVersion = %q, want %q (dev base from highest ancestor tag 1.0.1)", version, want)
 	}
 }
+
+// When a commit carries both a stable tag and a higher-patched RC tag, the RC
+// wins for versionsByHash (semver §11: 1.0.1-rc.1 > 1.0.0) while the stable
+// tag is still tracked in stableVersionsByHash.
+func Test_Repo_ResolveVersion_mixedStableRC_picksHighestSemver(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo, gitRepo := newTestRepo(t)
+	var warn bytes.Buffer
+	repo.warn = &warn
+
+	h := testCreateCommit(t, gitRepo, "a.txt", time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+	// RC created first to prove selection is by semver, not insertion order.
+	for _, tag := range []string{"v1.0.1-rc.1", "v1.0.0"} {
+		if _, err := gitRepo.CreateTag(tag, h, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	version, err := repo.ResolveVersion(ctx, h.String())
+	if err != nil {
+		t.Fatalf("ResolveVersion: unexpected error %v", err)
+	}
+	// compareSemver §11: v1.0.1-rc.1 > v1.0.0 (patch 1 > 0), so the RC is chosen.
+	if version != "1.0.1-rc.1" {
+		t.Errorf("ResolveVersion = %q, want %q", version, "1.0.1-rc.1")
+	}
+}

--- a/pkg/gitsemver/repo_test.go
+++ b/pkg/gitsemver/repo_test.go
@@ -923,27 +923,64 @@ func Test_Repo_ResolveVersion_nonReachableTagIgnored(t *testing.T) {
 	}
 }
 
-// A commit carrying two version tags must produce an error from ResolveVersion,
-// not silently return a randomly chosen version (symmetric with the NextVersion test).
-func Test_Repo_ResolveVersion_multipleTagsOnSameCommit_errors(t *testing.T) {
+// A commit carrying multiple version tags must not error: ResolveVersion picks
+// the highest-semver tag and emits a warning listing every discovered tag and
+// the one chosen.
+func Test_Repo_ResolveVersion_multipleTagsOnSameCommit_picksHighest(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	repo, gitRepo := newTestRepo(t)
+	var warn bytes.Buffer
+	repo.warn = &warn
 
 	h := testCreateCommit(t, gitRepo, "a.txt", time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
-	if _, err := gitRepo.CreateTag("v1.0.0", h, nil); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := gitRepo.CreateTag("v1.0.1", h, nil); err != nil {
-		t.Fatal(err)
+	// Created lowest-last to prove selection is by semver, not creation order.
+	for _, tag := range []string{"v1.0.1", "v1.2.0", "v1.0.0"} {
+		if _, err := gitRepo.CreateTag(tag, h, nil); err != nil {
+			t.Fatal(err)
+		}
 	}
 
-	_, err := repo.ResolveVersion(ctx, h.String())
-	var execErr *ExecutionFailedError
-	if !errors.As(err, &execErr) {
-		t.Fatalf("err = %T (%v), want *ExecutionFailedError", err, err)
+	version, err := repo.ResolveVersion(ctx, h.String())
+	if err != nil {
+		t.Fatalf("ResolveVersion: unexpected error %v", err)
 	}
-	if !strings.Contains(execErr.Error(), "multiple version tags") {
-		t.Errorf("unexpected error message: %v", execErr)
+	if version != "1.2.0" {
+		t.Errorf("ResolveVersion = %q, want %q (highest semver among the tags)", version, "1.2.0")
+	}
+
+	out := warn.String()
+	for _, want := range []string{"v1.0.0", "v1.0.1", "v1.2.0"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("warning %q does not list discovered tag %q", out, want)
+		}
+	}
+}
+
+// When an untagged commit's nearest ancestor carries multiple stable tags, the
+// dev-build base is derived from the highest of them.
+func Test_Repo_ResolveVersion_devBuild_multipleAncestorTags_picksHighest(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv(branchEnvVarName, "test-branch")
+
+	repo, gitRepo := newTestRepo(t)
+	var warn bytes.Buffer
+	repo.warn = &warn
+
+	base := testCreateCommit(t, gitRepo, "a.txt", time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+	for _, tag := range []string{"v1.0.0", "v1.0.1"} {
+		if _, err := gitRepo.CreateTag(tag, base, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	head := testCreateCommit(t, gitRepo, "b.txt", time.Date(2020, 1, 1, 1, 0, 0, 0, time.UTC))
+
+	version, err := repo.ResolveVersion(ctx, head.String())
+	if err != nil {
+		t.Fatalf("ResolveVersion: unexpected error %v", err)
+	}
+	const want = "1.0.2-dev.test-branch.2020-01-01.01-00-00"
+	if version != want {
+		t.Errorf("ResolveVersion = %q, want %q (dev base from highest ancestor tag 1.0.1)", version, want)
 	}
 }


### PR DESCRIPTION
## Problem

When gitsemver discovers the most recent tag reachable from HEAD, it can find multiple tags on a single commit (e.g. both `v1.0.0` and `v1.0.1` point at the same commit). In that case `buildVersionMaps` returned an `ExecutionFailedError` and both `get` (`ResolveVersion`) and `next` (`NextVersion`) failed outright.

## Fix

Instead of failing, gitsemver now picks the **highest tag in semver terms** and prints a **warning to stderr** listing every discovered tag and the chosen one. Stderr keeps the warning out of the version printed to stdout, so script consumers are unaffected.

- `Repo` gains a `warn io.Writer` field (defaults to `os.Stderr`; overridable in tests).
- `buildVersionMaps` collects all version tags (and stable tags) per commit and selects the highest of each via the existing `compareSemver`.
- New `highestVersionTag` helper reuses the in-house `parseVersionString` / `compareSemver`.

## Tests (TDD)

Written before the implementation:
- `Test_Repo_ResolveVersion_multipleTagsOnSameCommit_picksHighest` — highest tag returned, warning lists all tags (tags created lowest-last to prove ordering independence).
- `Test_Repo_ResolveVersion_devBuild_multipleAncestorTags_picksHighest` — dev-build base derives from the highest of multiple stable ancestor tags.
- `Test_Repo_NextVersion_multipleTagsOnSameCommit_picksHighest` — bump computed from the highest reachable tag.

The two prior tests asserting the error behavior were replaced.

## Scope note

`HeadTag` (public, but unused by any CLI command, and keeps non-version tags too) is intentionally left unchanged.

`go build`, `go vet`, `gofmt`, golangci-lint, and the full `go test ./...` suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)