### PR TITLE
feat(ci): release darwin and windows binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@8.3.0
+  architect: giantswarm/architect@9.1.0
 
 workflows:
   build:
@@ -14,7 +14,19 @@ workflows:
               only: /^v.*/
       - architect/go-build:
           binary: gitsemver
-          architectures: "linux/amd64,linux/arm64"
+          architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
           context: architect
           requires:
             - go-test-gitsemver
+          filters:
+            tags:
+              only: /^v.*/
+      - architect/upload-release-assets:
+          context: architect
+          requires:
+            - architect/go-build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ workflows:
             tags:
               only: /^v.*/
       - architect/upload-release-assets:
+          binary: gitsemver
           context: architect
           requires:
             - architect/go-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Release binaries now include darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64 alongside the existing linux targets. Windows binaries are named `gitsemver-windows-<arch>.exe`.
+
 ## [2.0.0] - 2026-06-02
 
 ### Changed


### PR DESCRIPTION
## What

- `go-build`: adds `darwin/amd64`, `darwin/arm64`, `windows/amd64`, `windows/arm64` to the `architectures` list.
- `upload-release-assets`: uploads signed bare binaries and cosign `.bundle` files to the GitHub Release on tags.
- Bumps architect orb to 9.1.0, which names Windows binaries `<binary>-windows-<arch>.exe` and adds cosign keyless signing and SBOM attestations.

Same pattern as giantswarm/muster#796.