### PR TITLE
feat: bound dev version length and add commit-hash segment

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,143 @@
+# gitsemver — project guide for AI agents
+
+## What this project does
+
+`gitsemver` is a Go CLI tool and library that computes semver-compatible version strings from a git
+repository's tag history.
+
+- `gitsemver get [--dir <path>] [--ref <ref>]` — resolves and prints the version for a git ref
+- `gitsemver next <bump-type> [--last-tag <tag>]` — computes the next semver tag
+- `gitsemver validate [--type dev|rc|stable|any] <version>` — validates a version string
+
+Version resolution rules:
+
+- Commit carrying `vX.Y.Z` → prints `X.Y.Z`
+- Commit carrying `vX.Y.Z-rc.N` → prints `X.Y.Z-rc.N`
+- Untagged commit → dev build: `X.Y.(Z+1)-dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS>`
+- When a commit carries multiple version tags, the **highest semver tag wins** and a warning is written to
+  `warn`
+
+## Module and package layout
+
+```
+github.com/giantswarm/gitsemver/v2   (module)
+main.go                               CLI entry point (cobra commands)
+main_test.go                          CLI integration tests
+pkg/gitsemver/
+  repo.go          Repo struct, New(), ResolveVersion(), NextVersion(), buildVersionMaps()
+  next.go          ComputeNextVersion(), parseVersionString(), compareSemver()
+  validate.go      IsValid*(), semver regex definitions (numID, semverParseRegex)
+  funcs.go         TopLevel(), HeadTag()
+  error.go         InvalidConfigError, ExecutionFailedError
+  devversion_test.go, repo_test.go, next_test.go, next_repo_test.go, ...
+pkg/project/       Version/GitSHA/BuildTimestamp metadata
+```
+
+## Environment variables
+
+| Var                     | Purpose                                                               |
+| ----------------------- | --------------------------------------------------------------------- |
+| `GS_BRANCH_NAME`        | Override branch name in dev builds                                    |
+| `GS_GIT_TAG_PREFIX`     | Monorepo: only consider tags with this prefix, e.g. `module-a/v1.2.3` |
+| `GS_MAX_VERSION_LENGTH` | Max dev version length (default 63, for Kubernetes labels)            |
+
+## Key architectural notes
+
+**Version maps.** `buildVersionMaps` produces two maps keyed by commit hash:
+
+- `versionsByHash` — highest semver tag (stable or RC) per commit
+- `stableVersionsByHash` — highest _stable-only_ tag per commit
+
+**Tag regexes:**
+
+- `tagRegex` matches `vX.Y.Z` and `vX.Y.Z-rc.N` (no leading zeros)
+- `stableTagRegex` matches only `vX.Y.Z`
+
+**`compareSemver` follows semver §11:** pre-release has lower precedence than stable at the same X.Y.Z. But an
+RC at a _higher patch_ beats a stable at a lower patch — e.g. `v1.0.1-rc.1 > v1.0.0`.
+
+**Warnings.** `Repo.warn io.Writer` defaults to `os.Stderr` so warnings never pollute stdout (script consumers
+use stdout). Library callers can redirect via `Config.WarnWriter`. Tests (same package) assign
+`repo.warn = &buf` directly.
+
+## Development workflow
+
+### Running tests
+
+Always write tests before or alongside implementation (TDD). Run the full suite before committing:
+
+```bash
+go test ./...
+```
+
+Run a focused subset during development:
+
+```bash
+go test ./pkg/gitsemver/... -run TestName -v
+```
+
+### Pre-commit hooks
+
+**Always run pre-commit before pushing.** The CI gate runs it and will fail the build if it's not clean. The
+hooks auto-fix some issues (trailing whitespace, gofmt, goimports) and leave the files modified on disk — you
+must stage and commit those fixes too.
+
+```bash
+pre-commit run --all-files
+```
+
+Common auto-fixes to watch for:
+
+- `trailing-whitespace` — fires on `CHANGELOG.md` edits easily
+- `go-fmt` / `go-imports` — will rewrite Go files in place
+
+Workflow when pre-commit auto-fixes files:
+
+1. Run `pre-commit run --all-files`
+2. If any hook reports "files were modified by this hook", stage the changed files
+3. Commit the fixes as a separate chore commit (e.g. `chore: fix trailing whitespace`)
+
+### Committing
+
+Stage files explicitly — never `git add -A` or `git add .`:
+
+```bash
+git add pkg/gitsemver/repo.go pkg/gitsemver/repo_test.go
+git commit -m "..."
+```
+
+The pre-commit hooks run automatically on `git commit`. If a hook fails:
+
+- It did **not** create a commit
+- Fix the issue, re-stage, and run `git commit` again (do **not** amend the previous commit)
+
+### Linters
+
+Pre-commit runs `golangci-lint` with these extra linters enabled: `gosec`, `goconst`, `govet`. Fix lint issues
+before committing.
+
+## Testing conventions
+
+Tests live in the same package (`package gitsemver`) so they can access unexported fields.
+
+Helper patterns used in `repo_test.go`:
+
+```go
+repo, gitRepo := newTestRepo(t)     // creates an in-memory git repo + Repo
+var warn bytes.Buffer
+repo.warn = &warn                   // capture warnings
+
+h := testCreateCommit(t, gitRepo, "file.txt", time.Date(...))
+gitRepo.CreateTag("v1.0.0", h, nil)
+```
+
+When testing multi-tag behaviour, create tags in an order that would expose insertion-order bugs (e.g. highest
+last, or RC before stable) to prove selection is semver-based.
+
+## PR review patterns learned (PR #254)
+
+- `%v` on `[]string` prints `[a b c]` — use `strings.Join(slice, ", ")` for readable output
+- Unexported fields that are meaningful to library callers should be exposed via `Config` struct fields (with
+  nil-default fallback), not buried as unexported-only
+- Cover the mixed stable + RC case explicitly in tests — the `compareSemver × multi-tag` interaction is the
+  subtlest part of the version resolution logic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Dev build versions now carry a trailing `.h<commit-sha>` segment (7-char git short hash of the resolved
+  commit) for tag-to-commit traceability, e.g. `1.2.4-dev.my-feature.2026-01-27.09-49-59.h1a2b3c4`.
+- Generated dev versions are bounded to a maximum length (default 63, configurable via `GS_MAX_VERSION_LENGTH`
+  or `Config.MaxVersionLength`) so they stay usable as Kubernetes/DNS attributes. Only the branch part is
+  shortened to fit: its middle is dropped and replaced with a `--` marker, keeping the head and the more
+  distinctive tail (e.g. `renovate-up--s-to-latest`). The base, timestamp and commit hash are always kept
+  intact, so per-branch chronological sort order is unaffected.
+
 ### Changed
 
+- Branch names embedded in dev versions are now lowercased and reduced to the DNS-safe set `[a-z0-9-]`
+  (hyphen runs collapsed, ends trimmed). Purely-numeric branch names have leading zeros stripped so the
+  segment is a valid semVer numeric identifier (e.g. `0042` -> `42`).
 - Release binaries now include darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64 alongside the existing linux targets. Windows binaries are named `gitsemver-windows-<arch>.exe`.
 
 ## [2.0.0] - 2026-06-02

--- a/README.md
+++ b/README.md
@@ -11,10 +11,19 @@ Library and CLI tool for computing a semVer-compatible version from a git refere
 |---|---|
 | HEAD carries stable tag `vX.Y.Z` | `X.Y.Z` |
 | HEAD carries pre-release tag `vX.Y.Z-rc.N` | `X.Y.Z-rc.N` |
-| HEAD is untagged, stable ancestor `vX.Y.Z` reachable | `X.Y.(Z+1)-dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS>` |
-| HEAD is untagged, no stable ancestor reachable | `0.0.0-dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS>` |
+| HEAD is untagged, stable ancestor `vX.Y.Z` reachable | `X.Y.(Z+1)-dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS>.h<commit-sha>` |
+| HEAD is untagged, no stable ancestor reachable | `0.0.0-dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS>.h<commit-sha>` |
 
-For untagged commits the base is the most recent **stable** ancestor tag reachable from the ref (RC and other pre-release tags are skipped). When no stable ancestor exists the version prefix is `0.0.0` with no patch increment.
+For untagged commits the base is the most recent **stable** ancestor tag reachable from the ref (RC and other pre-release tags are skipped). When no stable ancestor exists the version prefix is `0.0.0` with no patch increment. The trailing `.h<commit-sha>` is the 7-char git short hash of the resolved commit, for tag-to-commit traceability.
+
+### Length limit
+
+Dev build versions are often used as Kubernetes attributes, so they are kept DNS/label-compatible (lowercased, `[a-z0-9-]` only) and bounded to a maximum length (default **63**, configurable via `GS_MAX_VERSION_LENGTH`). Only the branch part is ever shortened to fit: when it would overflow, its middle is dropped and replaced with a `--` marker, keeping the head and the more distinctive tail (e.g. `renovate-up--s-to-latest`). The version base, timestamp and commit hash are always kept intact, so the per-branch chronological sort order is never affected.
+
+```sh
+$ GS_BRANCH_NAME=renovate/update-all-dependencies-to-latest gitsemver get
+1.2.4-dev.renovate-up--s-to-latest.2026-01-27.09-49-59.h1a2b3c4
+```
 
 ## Environment variables
 
@@ -22,6 +31,7 @@ For untagged commits the base is the most recent **stable** ancestor tag reachab
 |---|---|
 | `GS_BRANCH_NAME` | Override the branch name embedded in dev build versions. Defaults to the HEAD branch of the repo, then `"unknown"`. |
 | `GS_GIT_TAG_PREFIX` | Monorepo support: only consider tags prefixed with `"<value>/"`, e.g. `module-a/v1.2.3`. |
+| `GS_MAX_VERSION_LENGTH` | Maximum length of a generated dev build version. Defaults to `63`. Only the branch part is shortened to fit. |
 
 ## CLI — `gitsemver`
 
@@ -48,7 +58,7 @@ Print the version for a git ref:
 
 ```sh
 $ GS_BRANCH_NAME=my-feature gitsemver get
-1.2.4-dev.my-feature.2026-01-27.09-49-59
+1.2.4-dev.my-feature.2026-01-27.09-49-59.h1a2b3c4
 
 $ gitsemver get --ref v1.2.3
 1.2.3
@@ -117,5 +127,5 @@ c := gitsemver.Config{
 }
 repo, err := gitsemver.New(c)
 version, err := repo.ResolveVersion(ctx, "HEAD")
-// e.g. "1.2.4-dev.my-feature.2026-01-27.09-49-59"
+// e.g. "1.2.4-dev.my-feature.2026-01-27.09-49-59.h1a2b3c4"
 ```

--- a/main.go
+++ b/main.go
@@ -34,6 +34,10 @@
 //	                    "<value>/", e.g. "module-a/v1.2.3". The "next --last-tag"
 //	                    flag accepts both prefixed ("module-a/v1.2.3") and bare
 //	                    ("v1.2.3") forms; the prefix is stripped automatically.
+//	GS_MAX_VERSION_LENGTH
+//	                    Maximum length of a generated dev build version, so it
+//	                    stays usable as a Kubernetes attribute. Defaults to 63.
+//	                    Only the branch part is shortened to fit.
 package main
 
 import (

--- a/pkg/gitsemver/devversion_test.go
+++ b/pkg/gitsemver/devversion_test.go
@@ -83,6 +83,24 @@ func Test_buildDevVersion(t *testing.T) {
 		}
 	})
 
+	t.Run("multi-digit version base shrinks the branch budget", func(t *testing.T) {
+		branch := "renovate-update-all-dependencies-to-latest"
+		// The overhead is derived from len(base), so a wider base leaves less
+		// room for the branch. Every result must still be valid and within 63.
+		for _, base := range []string{"1.2.4", "10.12.346", "100.200.3456"} {
+			got, err := buildDevVersion(base, branch, sha, ts, 63)
+			if err != nil {
+				t.Fatalf("base %s: unexpected error: %v", base, err)
+			}
+			if len(got) > 63 {
+				t.Errorf("base %s: %q (len %d) exceeds the 63 char budget", base, got, len(got))
+			}
+			if !IsValidDev(got) {
+				t.Errorf("base %s: %q is not a valid dev version", base, got)
+			}
+		}
+	})
+
 	t.Run("commit hash uses the 7-char short form", func(t *testing.T) {
 		got, err := buildDevVersion("0.0.0", "main", sha, ts, 63)
 		if err != nil {

--- a/pkg/gitsemver/devversion_test.go
+++ b/pkg/gitsemver/devversion_test.go
@@ -1,0 +1,138 @@
+package gitsemver
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func Test_truncateBranch(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		branch   string
+		budget   int
+		expected string
+	}{
+		{"fits unchanged", "my-feature", 33, "my-feature"},
+		{"fits exactly", "my-feature", 10, "my-feature"},
+		{
+			name:     "middle dropped, head and tail kept",
+			branch:   "renovate-update-all-dependencies-to-latest",
+			budget:   24,
+			expected: "renovate-up--s-to-latest",
+		},
+		{
+			name:     "tail biased larger on odd budget",
+			branch:   "aaaaaaaaaabbbbbbbbbbcccccccccc",
+			budget:   13,
+			expected: "aaaaa--cccccc", // keep=11 → head 5, tail 6
+		},
+		{"tiny budget falls back to head cut", "abcdefghij", 3, "abc"},
+	}
+
+	for _, tc := range cases {
+		got := truncateBranch(tc.branch, tc.budget)
+		if got != tc.expected {
+			t.Errorf("%s: truncateBranch(%q, %d) = %q, want %q", tc.name, tc.branch, tc.budget, got, tc.expected)
+		}
+		if len(got) > tc.budget {
+			t.Errorf("%s: result %q exceeds budget %d", tc.name, got, tc.budget)
+		}
+		if strings.HasPrefix(got, "-") || strings.HasSuffix(got, "-") {
+			t.Errorf("%s: result %q must not start or end with a hyphen", tc.name, got)
+		}
+	}
+}
+
+func Test_buildDevVersion(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 1, 27, 9, 49, 59, 0, time.UTC)
+	sha := "1a2b3c4d5e6f7a8b9c0d"
+
+	t.Run("short branch keeps the full name", func(t *testing.T) {
+		got, err := buildDevVersion("1.2.4", "my-feature", sha, ts, 63)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := "1.2.4-dev.my-feature.2026-01-27.09-49-59.h1a2b3c4"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+		if !IsValidDev(got) {
+			t.Errorf("%q is not a valid dev version", got)
+		}
+	})
+
+	t.Run("long branch is middle-truncated to fit", func(t *testing.T) {
+		got, err := buildDevVersion("1.2.4", "renovate-update-all-dependencies-to-latest", sha, ts, 63)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := "1.2.4-dev.renovate-up--s-to-latest.2026-01-27.09-49-59.h1a2b3c4"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+		if len(got) > 63 {
+			t.Errorf("result %q (len %d) exceeds the 63 char budget", got, len(got))
+		}
+		if !IsValidDev(got) {
+			t.Errorf("%q is not a valid dev version", got)
+		}
+	})
+
+	t.Run("commit hash uses the 7-char short form", func(t *testing.T) {
+		got, err := buildDevVersion("0.0.0", "main", sha, ts, 63)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.HasSuffix(got, ".h1a2b3c4") {
+			t.Errorf("got %q, want trailing .h1a2b3c4", got)
+		}
+	})
+
+	t.Run("errors when the fixed parts do not fit", func(t *testing.T) {
+		_, err := buildDevVersion("1.2.4", "main", sha, ts, 20)
+		if err == nil {
+			t.Errorf("expected an error for an impossibly small budget")
+		}
+	})
+
+	t.Run("per-branch order follows the timestamp", func(t *testing.T) {
+		older, _ := buildDevVersion("1.2.4", "feature", sha, ts, 63)
+		newer, _ := buildDevVersion("1.2.4", "feature", sha, ts.Add(time.Hour), 63)
+		// Same branch and hash, so the timestamp segment decides order and the
+		// lexical comparison of the full strings matches chronological order.
+		if older >= newer {
+			t.Errorf("expected %q < %q", older, newer)
+		}
+	})
+}
+
+func Test_resolveMaxVersionLength(t *testing.T) {
+	cases := []struct {
+		name       string
+		configured int
+		env        string
+		expected   int
+	}{
+		{"default when nothing set", 0, "", defaultMaxVersionLength},
+		{"configured value wins", 80, "100", 80},
+		{"env used when not configured", 0, "100", 100},
+		{"invalid env falls back to default", 0, "not-a-number", defaultMaxVersionLength},
+		{"non-positive env falls back to default", 0, "0", defaultMaxVersionLength},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// An empty value is treated as unset by resolveMaxVersionLength.
+			t.Setenv(maxVersionLengthEnvVarName, tc.env)
+			got := resolveMaxVersionLength(tc.configured)
+			if got != tc.expected {
+				t.Errorf("resolveMaxVersionLength(%d) with env %q = %d, want %d", tc.configured, tc.env, got, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/gitsemver/repo.go
+++ b/pkg/gitsemver/repo.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	billy "github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/osfs"
@@ -34,11 +35,32 @@ var prefixedTagRegex = regexp.MustCompile(`^[a-zA-Z0-9-_]+/v[0-9]+\.[0-9]+\.[0-9
 
 var branchEnvVarName = "GS_BRANCH_NAME"
 
-// branchSanitizeRegex replaces one or more consecutive invalid semVer
-// pre-release characters with a single hyphen.
-var branchSanitizeRegex = regexp.MustCompile(`[^a-zA-Z0-9-]+`)
+// branchSanitizeRegex matches one or more consecutive characters that are not
+// valid in a DNS label / semVer pre-release identifier (anything outside
+// [a-z0-9]). A run is replaced with a single hyphen, which also collapses
+// existing hyphen runs so that "--" is reserved as the truncation marker.
+var branchSanitizeRegex = regexp.MustCompile(`[^a-z0-9]+`)
 
 const unknownBranch = "unknown"
+
+const (
+	// defaultMaxVersionLength is the DNS-1123 label / Kubernetes label-value
+	// length limit. Generated dev versions are bounded to it by default so they
+	// stay usable as Kubernetes attributes.
+	defaultMaxVersionLength = 63
+	// maxVersionLengthEnvVarName overrides the maximum generated version length.
+	maxVersionLengthEnvVarName = "GS_MAX_VERSION_LENGTH"
+	// devShortSHALen is the number of hex characters of the commit hash kept in
+	// a dev version, matching the conventional git short-hash length.
+	devShortSHALen = 7
+	// devTruncationMarker is inserted in place of the dropped middle of an
+	// over-long branch name.
+	devTruncationMarker = "--"
+	// devHashPrefix prefixes the commit hash so the segment is always
+	// alphanumeric, hence compared lexically by semVer and never an illegal
+	// all-digit identifier with a leading zero.
+	devHashPrefix = "h"
+)
 
 // currentBranch returns the name of the branch to embed in dev build versions.
 // Priority: GS_BRANCH_NAME env var > HEAD branch of CWD git repo > unknownBranch.
@@ -57,8 +79,110 @@ func currentBranch() string {
 	return head.Name().Short()
 }
 
+// sanitizeBranchName reduces a branch name to the DNS-label / semVer-safe
+// character set [a-z0-9-]: it lowercases, replaces every run of other
+// characters (and hyphen runs) with a single hyphen and trims leading/trailing
+// hyphens. An empty result falls back to unknownBranch.
+//
+// A purely-numeric result is a semVer numeric identifier, which forbids leading
+// zeros (spec §9), so leading zeros are stripped to keep the dev version a valid
+// semVer string (e.g. branch "0042" -> "42"). A name containing any non-digit is
+// an alphanumeric identifier where leading zeros are allowed and kept.
 func sanitizeBranchName(branch string) string {
-	return branchSanitizeRegex.ReplaceAllString(branch, "-")
+	b := strings.Trim(branchSanitizeRegex.ReplaceAllString(strings.ToLower(branch), "-"), "-")
+	if b == "" {
+		return unknownBranch
+	}
+	if isAllDigits(b) {
+		if b = strings.TrimLeft(b, "0"); b == "" {
+			b = "0"
+		}
+	}
+	return b
+}
+
+// isAllDigits reports whether s is non-empty and consists solely of ASCII digits.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// resolveMaxVersionLength determines the maximum allowed length of a generated
+// version string. An explicit positive configured value wins; otherwise the
+// GS_MAX_VERSION_LENGTH env var (when a positive integer) is used; otherwise
+// defaultMaxVersionLength.
+func resolveMaxVersionLength(configured int) int {
+	if configured > 0 {
+		return configured
+	}
+	if v := strings.TrimSpace(os.Getenv(maxVersionLengthEnvVarName)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultMaxVersionLength
+}
+
+// truncateBranch shortens branch to at most budget characters. A branch that
+// already fits is returned unchanged. Otherwise its middle is dropped and
+// replaced with the "--" marker, keeping the head and the (more distinctive)
+// tail, e.g. "renovate-update-all-deps" -> "renovate-up--all-deps". When the
+// budget is too small to keep both ends the branch is cut to its head. The
+// result never starts or ends with a hyphen.
+func truncateBranch(branch string, budget int) string {
+	if budget < 1 {
+		budget = 1
+	}
+	if len(branch) <= budget {
+		return branch
+	}
+	// Not enough room for head + marker + at least one tail char: plain cut.
+	if budget < len(devTruncationMarker)+2 {
+		return strings.TrimRight(branch[:budget], "-")
+	}
+	keep := budget - len(devTruncationMarker)
+	headLen := keep / 2
+	tailLen := keep - headLen
+	head := strings.TrimRight(branch[:headLen], "-")
+	tail := strings.TrimLeft(branch[len(branch)-tailLen:], "-")
+	return head + devTruncationMarker + tail
+}
+
+// buildDevVersion assembles a dev build version of the form
+// "X.Y.Z-dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS>.h<sha>" bounded to maxLen
+// characters. Only the branch is shortened to fit (see truncateBranch); the
+// version base, timestamp and commit hash are always preserved, so the
+// per-branch chronological sort order is never affected. commitSHA is the full
+// commit hash; its first devShortSHALen hex characters are embedded. It returns
+// an error when even the fixed parts do not fit maxLen.
+func buildDevVersion(base, branch, commitSHA string, t time.Time, maxLen int) (string, error) {
+	date := t.Format("2006-01-02")
+	clock := t.Format("15-04-05")
+	short := commitSHA
+	if len(short) > devShortSHALen {
+		short = short[:devShortSHALen]
+	}
+	hash := devHashPrefix + short
+
+	// Characters consumed by everything except the branch:
+	//   base + "-dev." + branch + "." + date + "." + clock + "." + hash
+	overhead := len(base) + len("-dev.") + 1 + len(date) + 1 + len(clock) + 1 + len(hash)
+	branchBudget := maxLen - overhead
+	if branchBudget < 1 {
+		return "", &ExecutionFailedError{message: fmt.Sprintf(
+			"cannot fit a dev version for base %q within %d characters (fixed parts need %d)",
+			base, maxLen, overhead+1)}
+	}
+
+	branch = truncateBranch(branch, branchBudget)
+	return fmt.Sprintf("%s-dev.%s.%s.%s.%s", base, branch, date, clock, hash), nil
 }
 
 func incrementPatch(version string) (string, error) {
@@ -78,6 +202,9 @@ type Config struct {
 	AuthBasicToken string
 	Dir            string
 	URL            string
+	// MaxVersionLength bounds the length of generated dev versions. When <= 0
+	// the GS_MAX_VERSION_LENGTH env var or the default of 63 is used.
+	MaxVersionLength int
 }
 
 type Repo struct {
@@ -86,6 +213,8 @@ type Repo struct {
 	auth     transport.AuthMethod
 	storage  *filesystem.Storage
 	worktree billy.Filesystem
+
+	maxVersionLength int
 }
 
 func New(config Config) (*Repo, error) {
@@ -136,6 +265,8 @@ func New(config Config) (*Repo, error) {
 		auth:     auth,
 		storage:  storage,
 		worktree: worktree,
+
+		maxVersionLength: config.MaxVersionLength,
 	}
 
 	return r, nil
@@ -318,13 +449,19 @@ func buildVersionMaps(tagsByHash map[string][]string, tagPrefix string) (version
 //   - Stable tag vX.Y.Z on the commit → returns "X.Y.Z"
 //   - Pre-release tag vX.Y.Z-<pre> on the commit → returns "X.Y.Z-<pre>" (e.g. "1.2.3-rc.1")
 //   - Untagged commit → returns a semVer dev build:
-//     "X.Y.(Z+1)-dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS>"
+//     "X.Y.(Z+1)-dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS>.h<commit-sha>"
 //     where X.Y.Z is the most recent stable (non-pre-release) ancestor tag reachable
 //     from the reference, or "0.0.0" when no stable ancestor exists. The timestamp is
 //     the committer date (in UTC) of the resolved commit, so the version is stable for
-//     a given commit. The branch name is resolved from GS_BRANCH_NAME env var, then the
-//     HEAD branch of the CWD git repo, then "unknown". Non-reachable tags are never used
-//     as the base.
+//     a given commit. The trailing ".h<commit-sha>" is the 7-char git short hash of the
+//     resolved commit, for tag-to-commit traceability. The branch name is resolved from
+//     GS_BRANCH_NAME env var, then the HEAD branch of the CWD git repo, then "unknown".
+//     Non-reachable tags are never used as the base.
+//
+// The whole version is bounded to MaxVersionLength characters (GS_MAX_VERSION_LENGTH
+// env var, default 63) so it stays usable as a Kubernetes attribute. Only the branch
+// part is shortened to fit (its middle is replaced with a "--" marker); the base,
+// timestamp and commit hash are always kept intact.
 //
 // If GS_GIT_TAG_PREFIX is set, only tags prefixed with "<value>/" are considered,
 // e.g. "module-a/v1.2.3". The prefix, separator, and "v" are stripped from the result.
@@ -426,12 +563,10 @@ func (r *Repo) ResolveVersion(ctx context.Context, ref string) (string, error) {
 	}
 	branch := sanitizeBranchName(currentBranch())
 	t := commit.Committer.When.UTC()
-	pseudoVersion := fmt.Sprintf("%s-dev.%s.%s.%s",
-		base,
-		branch,
-		t.Format("2006-01-02"),
-		t.Format("15-04-05"),
-	)
+	pseudoVersion, err := buildDevVersion(base, branch, commit.Hash.String(), t, resolveMaxVersionLength(r.maxVersionLength))
+	if err != nil {
+		return "", err
+	}
 
 	return pseudoVersion, nil
 }

--- a/pkg/gitsemver/repo_test.go
+++ b/pkg/gitsemver/repo_test.go
@@ -472,8 +472,24 @@ func Test_Repo_ResolveVersion(t *testing.T) {
 					t.Fatalf("error == %#v, want matching", err)
 				}
 
-				if version != tc.expectedVersion {
-					t.Errorf("got %q, expected %q\n", version, tc.expectedVersion)
+				// Dev versions carry a trailing ".h<7-hex>" short hash of the
+				// resolved commit. Derive it from the same ref so the table can
+				// keep the stable, hash-free prefix as the expectation.
+				expected := tc.expectedVersion
+				if strings.Contains(expected, "-dev.") {
+					gitRepo, err := git.Open(repo.storage, repo.worktree)
+					if err != nil {
+						t.Fatalf("opening repo to resolve commit hash: %v", err)
+					}
+					h, err := gitRepo.ResolveRevision(plumbing.Revision(tc.inputRef))
+					if err != nil {
+						t.Fatalf("resolving %q: %v", tc.inputRef, err)
+					}
+					expected += ".h" + h.String()[:devShortSHALen]
+				}
+
+				if version != expected {
+					t.Errorf("got %q, expected %q\n", version, expected)
 				}
 			}
 		})
@@ -715,7 +731,17 @@ func Test_sanitizeBranchName(t *testing.T) {
 		{"feat/sub/deep", "feat-sub-deep"},
 		{"already-clean-123", "already-clean-123"},
 		{"feat//double-slash", "feat-double-slash"}, // consecutive invalid chars → single hyphen
-		{"__leading", "-leading"},                   // leading invalid chars
+		{"__leading", "leading"},                    // leading invalid chars trimmed
+		{"trailing__", "trailing"},                  // trailing invalid chars trimmed
+		{"Feature/MyThing", "feature-mything"},      // lowercased
+		{"UPPER", "upper"},                          // lowercased
+		{"a--b", "a-b"},                             // hyphen runs collapsed ("--" reserved as marker)
+		{"///", "unknown"},                          // empty result falls back to unknownBranch
+		{"0042", "42"},                              // all-digit branch: leading zeros stripped (illegal semVer numeric id)
+		{"007", "7"},                                // all-digit branch: leading zeros stripped
+		{"000", "0"},                                // all zeros collapse to a single "0"
+		{"42", "42"},                                // numeric without leading zero is kept
+		{"0-1", "0-1"},                              // contains a hyphen → alphanumeric id, leading zero kept
 	}
 
 	for _, tc := range cases {
@@ -860,8 +886,9 @@ func Test_Repo_ResolveVersion_rcAncestor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Timestamp is the committer date of the HEAD commit (base + 2h).
-	const want = "1.0.1-dev.test-branch.2020-01-01.02-00-00"
+	// Timestamp is the committer date of the HEAD commit (base + 2h); the
+	// trailing segment is the short hash of the resolved HEAD commit.
+	want := "1.0.1-dev.test-branch.2020-01-01.02-00-00.h" + headHash.String()[:devShortSHALen]
 	if version != want {
 		t.Errorf("ResolveVersion = %q, want %q — RC ancestor must be skipped, base must come from v1.0.0", version, want)
 	}
@@ -916,8 +943,9 @@ func Test_Repo_ResolveVersion_nonReachableTagIgnored(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Timestamp is the committer date of the HEAD commit (base + 2h).
-	const want = "1.0.1-dev.test-branch.2020-01-01.02-00-00"
+	// Timestamp is the committer date of the HEAD commit (base + 2h); the
+	// trailing segment is the short hash of the resolved HEAD commit.
+	want := "1.0.1-dev.test-branch.2020-01-01.02-00-00.h" + headHash.String()[:devShortSHALen]
 	if version != want {
 		t.Errorf("ResolveVersion = %q, want %q — non-reachable v2.0.0 on side branch must be ignored", version, want)
 	}

--- a/pkg/gitsemver/validate.go
+++ b/pkg/gitsemver/validate.go
@@ -12,7 +12,10 @@ const vXYZ = `v?` + numID + `\.` + numID + `\.` + numID
 
 var validStableRegex = regexp.MustCompile(`^` + vXYZ + `$`)
 var validRCRegex = regexp.MustCompile(`^` + vXYZ + `-rc\.` + numID + `$`)
-var validDevRegex = regexp.MustCompile(`^` + vXYZ + `-dev\.[a-zA-Z0-9-]+\.[0-9]{4}-[0-9]{2}-[0-9]{2}\.[0-9]{2}-[0-9]{2}-[0-9]{2}$`)
+
+// The trailing ".h<7-hex>" commit-hash segment is optional so that dev tags
+// generated before it was introduced still validate; generation always emits it.
+var validDevRegex = regexp.MustCompile(`^` + vXYZ + `-dev\.[a-zA-Z0-9-]+\.[0-9]{4}-[0-9]{2}-[0-9]{2}\.[0-9]{2}-[0-9]{2}-[0-9]{2}(?:\.h[0-9a-f]{7})?$`)
 
 // IsValidStable reports whether version is a valid stable release version
 // (X.Y.Z or vX.Y.Z, no leading zeros in any component).
@@ -27,8 +30,10 @@ func IsValidRC(version string) bool {
 }
 
 // IsValidDev reports whether version is a valid dev-build version
-// (X.Y.Z-dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS> or with a leading v,
-// no leading zeros in X.Y.Z components).
+// (X.Y.Z-dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS>[.h<7-hex>] or with a leading v,
+// no leading zeros in X.Y.Z components). The trailing commit-hash segment is
+// optional. This checks the format only, not the length budget enforced when a
+// dev version is generated.
 func IsValidDev(version string) bool {
 	return validDevRegex.MatchString(version)
 }

--- a/pkg/gitsemver/validate_test.go
+++ b/pkg/gitsemver/validate_test.go
@@ -98,6 +98,13 @@ func Test_IsValidDev(t *testing.T) {
 		"1.0.1-dev.feature-my-thing.2026-05-21.14-30-00",
 		// single-char branch
 		"1.0.0-dev.x.2026-05-21.00-00-00",
+		// with the optional commit-hash segment
+		"1.2.4-dev.my-feature.2026-01-27.09-49-59.h1a2b3c4",
+		"v1.2.3-dev.main.2026-01-27.09-49-59.habc1234",
+		// all-digit hash (legal because the "h" prefix keeps it alphanumeric)
+		"1.2.4-dev.main.2026-01-27.09-49-59.h0012345",
+		// middle-truncated branch with the "--" marker
+		"1.2.4-dev.renovate-up--s-to-latest.2026-01-27.09-49-59.h1a2b3c4",
 	}
 	invalid := []string{
 		"",
@@ -105,6 +112,14 @@ func Test_IsValidDev(t *testing.T) {
 		"1.2.3-rc.1",
 		// missing time segment
 		"1.2.3-dev.main.2026-01-27",
+		// commit-hash segment missing the "h" prefix
+		"1.2.3-dev.main.2026-01-27.09-49-59.1a2b3c4",
+		// commit-hash too short / too long
+		"1.2.3-dev.main.2026-01-27.09-49-59.h1a2b3c",
+		"1.2.3-dev.main.2026-01-27.09-49-59.h1a2b3c45",
+		// commit-hash not lowercase hex
+		"1.2.3-dev.main.2026-01-27.09-49-59.hABC1234",
+		"1.2.3-dev.main.2026-01-27.09-49-59.hxyz1234",
 		// wrong date separator (slashes)
 		"1.2.3-dev.main.2026/01/27.09-49-59",
 		// wrong time separator (colons)


### PR DESCRIPTION
## What

Makes generated **dev build versions** safe to use as Kubernetes attributes: DNS/label-compatible and bounded in length, while staying valid, sortable semVer.

New format:

```
X.Y.Z-dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS>.h<commit-sha>
```

e.g. `1.2.4-dev.my-feature.2026-01-27.09-49-59.h1a2b3c4`

## Why

These tags end up as OCI image tags, Helm chart versions, and Kubernetes label values (`app.kubernetes.io/version`, etc.), which cap at **63 chars** and require a DNS/label-safe charset. Long branch names (e.g. `renovate/update-all-dependencies-to-latest`) previously overflowed that limit. Spec was agreed in the [`semver-based-automatic-upgrades` RFC](https://github.com/giantswarm/giantswarm) (updated separately).

## Changes

- **Length budget** (default `63`, configurable via `GS_MAX_VERSION_LENGTH` env or `Config.MaxVersionLength`). Only the **branch** is shortened to fit; the base, timestamp and commit hash are always kept intact, so **per-branch chronological sort order is never affected**.
- **Middle truncation**: when the branch overflows, its middle is dropped and replaced with a `--` marker, keeping the head and the more distinctive tail (e.g. `renovate-up--s-to-latest`).
- **Commit-hash segment** `.h<sha7>` for tag→commit traceability. The `h` prefix keeps the segment alphanumeric so it's compared lexically and never an illegal all-digit/leading-zero semVer identifier.
- **Tighter branch sanitization**: lowercase, reduce to `[a-z0-9-]`, collapse hyphen runs, trim ends, fall back to `unknown` when empty, and **strip leading zeros from purely-numeric branches** (`0042` → `42`) so the segment is a valid semVer numeric identifier.
- **Validation**: `IsValidDev` accepts the optional `.h<7-hex>` segment (lenient for already-released tags; generation always emits it).

## Ordering guarantee

For builds on the same branch the branch segment is identical, so order is decided by the date/time segments before the hash is ever reached — newer commit sorts higher.

## Tests

- New `devversion_test.go`: `truncateBranch`, `buildDevVersion` (incl. the 63-char `renovate-up--s-to-latest` case and the per-branch ordering invariant), `resolveMaxVersionLength`.
- `validate_test.go`: hash-bearing valid cases (incl. all-digit `h0012345`, `--` branch) and bad-hash invalid cases.
- `repo_test.go`: integration cases now derive the `.hSHA` suffix from the resolved commit (verifies real tag↔commit matching); sanitize cases cover lowercase/collapse/trim/empty-fallback/numeric-leading-zero.

Note: a `/code-review` pass flagged that an all-digit branch with a leading zero produced an illegal semVer identifier (`IsValidDev` false-positive) — fixed in this PR via the leading-zero strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)